### PR TITLE
fix: proper type export

### DIFF
--- a/scripts/make-package.mjs
+++ b/scripts/make-package.mjs
@@ -33,6 +33,7 @@ import fs from "node:fs/promises";
         ".": {
             import: "./index.js",
             require: "./index.cjs",
+            types: "./index.d.ts",
         },
         "./*js": "./*js",
         "./*": {


### PR DESCRIPTION
Typescript complains of "Cannot find a declaration module or file", mostly for `@unified-latex/unified-latex-types` and `@unified-latex/unified-latex-builder`.
It does not _always_ do this, which is weird, but if I put this in the outputted `package.json` it always works properly.

```diff
       "exports": {
           ".": {
               "import": "./index.js",
               "require": "./index.cjs",
+++            "types": "./index.d.ts"
           },
```

This PR adds this field by default. I'm not sure if this will break some packages or not, you might have a better idea of that!

