### PR TITLE
Add getParser() to inject plugin options

### DIFF
--- a/packages/unified-latex-util-parse/README.md
+++ b/packages/unified-latex-util-parse/README.md
@@ -160,6 +160,21 @@ function parseMinimal(str: String): Ast.Root;
 | :---- | :------- |
 | str   | `String` |
 
+## `getParser(PluginOptions)`
+
+Returns the default `unified-latex` parser if the argument is `undefined`, or
+create a new one with the provided `unifiedLatexFromString` options.
+
+```typescript
+function getParser(options?: PluginOptions): FrozenProcessor<Ast.Root, Ast.Root, Ast.Root, void>;
+```
+
+**Parameters**
+
+| Param  | Type            |
+| :----- | :-------------- |
+| option | `PluginOptions` |
+
 # Types
 
 ## `PluginOptions`

--- a/packages/unified-latex-util-parse/libs/parse.ts
+++ b/packages/unified-latex-util-parse/libs/parse.ts
@@ -19,6 +19,10 @@ export function parse(str: string): Ast.Root {
  * @returns The default `unified-latex` parser if `options` is `undefined`, or a
  * newly created `unified-latex` parser with the provided `options`.
  */
-export function getParser(options?: PluginOptions): FrozenProcessor<Ast.Root, Ast.Root, Ast.Root, void> {
-    return options ? unified().use(unifiedLatexFromString, options).freeze() : parser
+export function getParser(
+    options?: PluginOptions
+): FrozenProcessor<Ast.Root, Ast.Root, Ast.Root, void> {
+    return options
+        ? unified().use(unifiedLatexFromString, options).freeze()
+        : parser;
 }

--- a/packages/unified-latex-util-parse/libs/parse.ts
+++ b/packages/unified-latex-util-parse/libs/parse.ts
@@ -1,12 +1,24 @@
 import * as Ast from "@unified-latex/unified-latex-types";
-import { unified } from "unified";
+import { type FrozenProcessor, unified } from "unified";
 import { unifiedLatexFromString } from "./plugin-from-string";
+import type { PluginOptions } from "./plugin-from-string";
 
-const parser = unified().use(unifiedLatexFromString).freeze();
+let parser = unified().use(unifiedLatexFromString).freeze();
 
 /**
  * Parse the string into an AST.
  */
 export function parse(str: string): Ast.Root {
     return parser.parse(str);
+}
+
+/**
+ * Returns the default `unified-latex` parser, or create a new one with the
+ * provided `unifiedLatexFromString` options
+ * @param options Plugin options of `unifiedLatexFromString` plugin.
+ * @returns The default `unified-latex` parser if `options` is `undefined`, or a
+ * newly created `unified-latex` parser with the provided `options`.
+ */
+export function getParser(options?: PluginOptions): FrozenProcessor<Ast.Root, Ast.Root, Ast.Root, void> {
+    return options ? unified().use(unifiedLatexFromString, options).freeze() : parser
 }


### PR DESCRIPTION
This PR adds a `getParser()` function to `unified-latex-util-parse` package.

This PR partially resolve the issue in #32 . The actual use case is that, it seems not possible to avoid directly importing `unifiedjs` when trying to pass plugin options of `unifiedLatexFromString` to the parser. When working on platforms without ESM support (e.g., electron), this becomes almost impossible to customize the LaTeX parser.

With this new function, user can indirectly invoke the `use()` of `unified` to create a LaTeX parser with custom macros and envs. A possible use case is illustrated at https://github.com/James-Yu/LaTeX-Workshop/blob/unified-latex/src/components/parser.ts#L163-L200 .

This PR will have full effect with another PR shortly on bundling ESM dependencies when creating `.cjs` distributions.