### PR TITLE
Do not externalize ESM in cjs

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,5 +73,6 @@
         "vfile-reporter-position": "^0.1.7",
         "vfile-reporter-pretty": "^6.1.0"
     },
+    "internalDependencies": "/unified|bail|is-plain-obj|trough|vfile.*|unist.*|hast.*|property-information|html-void-elements|.*-separated-tokens|.*entities.*|ccount|rehype*|string-width|strip-ansi|ansi-regex|supports-color|rehype|web-namespaces|zwitch/",
     "name": "unified-latex"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
     "private": true,
     "workspaces": [
+        "./packages/unified-latex-util-pegjs",
         "./packages/*"
     ],
     "scripts": {

--- a/package.json
+++ b/package.json
@@ -74,6 +74,5 @@
         "vfile-reporter-position": "^0.1.7",
         "vfile-reporter-pretty": "^6.1.0"
     },
-    "internalDependencies": "/unified|bail|is-plain-obj|trough|vfile.*|unist.*|hast.*|property-information|html-void-elements|.*-separated-tokens|.*entities.*|ccount|rehype*|string-width|strip-ansi|ansi-regex|supports-color|rehype|web-namespaces|zwitch/",
     "name": "unified-latex"
 }

--- a/packages/structured-clone/build.js
+++ b/packages/structured-clone/build.js
@@ -1,6 +1,5 @@
 import esbuild from "esbuild";
 import fs from "node:fs/promises";
-import { COMPILE_PKG_REGEXP } from "../unified-latex/build.js";
 
 (async () => {
     const packageJson = JSON.parse(
@@ -28,7 +27,7 @@ import { COMPILE_PKG_REGEXP } from "../unified-latex/build.js";
     esbuild
         .build({
             ...commonConfig,
-            external: commonConfig.external.filter(dep => !COMPILE_PKG_REGEXP.exec(dep)),
+            external: commonConfig.external.filter(dep => !new RegExp(packageJson.internalDependencies).exec(dep)),
             outfile: "./dist/index.cjs",
             format: "cjs",
         })

--- a/packages/structured-clone/build.js
+++ b/packages/structured-clone/build.js
@@ -1,6 +1,6 @@
 import esbuild from "esbuild";
 import fs from "node:fs/promises";
-import { isExternal } from "../../scripts/esbuild-module-check.mjs";
+import { isCjsPackage } from "../../scripts/esbuild-module-check.mjs";
 
 (async () => {
     const packageJson = JSON.parse(
@@ -28,7 +28,7 @@ import { isExternal } from "../../scripts/esbuild-module-check.mjs";
     esbuild
         .build({
             ...commonConfig,
-            external: commonConfig.external.filter(isExternal),
+            external: commonConfig.external.filter(isCjsPackage),
             outfile: "./dist/index.cjs",
             format: "cjs",
         })

--- a/packages/structured-clone/build.js
+++ b/packages/structured-clone/build.js
@@ -1,5 +1,6 @@
 import esbuild from "esbuild";
 import fs from "node:fs/promises";
+import { COMPILE_PKG_REGEXP } from "../unified-latex/build.js";
 
 (async () => {
     const packageJson = JSON.parse(
@@ -27,7 +28,7 @@ import fs from "node:fs/promises";
     esbuild
         .build({
             ...commonConfig,
-            external: commonConfig.external.filter(dep => !/unified|bail|is-plain-obj|trough|vfile.*|unist.*|hast.*|property-information|html-void-elements|.*-separated-tokens|.*entities.*|ccount|rehype*|string-width|strip-ansi|ansi-regex|supports-color|rehype|web-namespaces|zwitch/.exec(dep)),
+            external: commonConfig.external.filter(dep => !COMPILE_PKG_REGEXP.exec(dep)),
             outfile: "./dist/index.cjs",
             format: "cjs",
         })

--- a/packages/structured-clone/build.js
+++ b/packages/structured-clone/build.js
@@ -1,5 +1,6 @@
 import esbuild from "esbuild";
 import fs from "node:fs/promises";
+import { isExternal } from "../../scripts/esbuild-module-check.mjs";
 
 (async () => {
     const packageJson = JSON.parse(
@@ -27,7 +28,7 @@ import fs from "node:fs/promises";
     esbuild
         .build({
             ...commonConfig,
-            external: commonConfig.external.filter(dep => !new RegExp(packageJson.internalDependencies).exec(dep)),
+            external: commonConfig.external.filter(isExternal),
             outfile: "./dist/index.cjs",
             format: "cjs",
         })

--- a/packages/structured-clone/build.js
+++ b/packages/structured-clone/build.js
@@ -27,6 +27,7 @@ import fs from "node:fs/promises";
     esbuild
         .build({
             ...commonConfig,
+            external: commonConfig.external.filter(dep => !/unified|bail|is-plain-obj|trough|vfile.*|unist.*|hast.*|property-information|html-void-elements|.*-separated-tokens|.*entities.*|ccount|rehype*|string-width|strip-ansi|ansi-regex|supports-color|rehype|web-namespaces|zwitch/.exec(dep)),
             outfile: "./dist/index.cjs",
             format: "cjs",
         })

--- a/packages/support-tables/build.js
+++ b/packages/support-tables/build.js
@@ -1,6 +1,6 @@
 import esbuild from "esbuild";
 import fs from "node:fs/promises";
-import { isExternal } from "../../scripts/esbuild-module-check.mjs";
+import { isCjsPackage } from "../../scripts/esbuild-module-check.mjs";
 
 (async () => {
     const packageJson = JSON.parse(
@@ -28,7 +28,7 @@ import { isExternal } from "../../scripts/esbuild-module-check.mjs";
     esbuild
         .build({
             ...commonConfig,
-            external: commonConfig.external.filter(isExternal),
+            external: commonConfig.external.filter(isCjsPackage),
             format: "cjs",
             outExtension: { ".js": ".cjs" },
         })

--- a/packages/support-tables/build.js
+++ b/packages/support-tables/build.js
@@ -1,6 +1,5 @@
 import esbuild from "esbuild";
 import fs from "node:fs/promises";
-import { COMPILE_PKG_REGEXP } from "../unified-latex/build.js";
 
 (async () => {
     const packageJson = JSON.parse(
@@ -28,7 +27,7 @@ import { COMPILE_PKG_REGEXP } from "../unified-latex/build.js";
     esbuild
         .build({
             ...commonConfig,
-            external: commonConfig.external.filter(dep => !COMPILE_PKG_REGEXP.exec(dep)),
+            external: commonConfig.external.filter(dep => !new RegExp(packageJson.internalDependencies).exec(dep)),
             format: "cjs",
             outExtension: { ".js": ".cjs" },
         })

--- a/packages/support-tables/build.js
+++ b/packages/support-tables/build.js
@@ -27,6 +27,7 @@ import fs from "node:fs/promises";
     esbuild
         .build({
             ...commonConfig,
+            external: commonConfig.external.filter(dep => !/unified|bail|is-plain-obj|trough|vfile.*|unist.*|hast.*|property-information|html-void-elements|.*-separated-tokens|.*entities.*|ccount|rehype*|string-width|strip-ansi|ansi-regex|supports-color|rehype|web-namespaces|zwitch/.exec(dep)),
             format: "cjs",
             outExtension: { ".js": ".cjs" },
         })

--- a/packages/support-tables/build.js
+++ b/packages/support-tables/build.js
@@ -1,5 +1,6 @@
 import esbuild from "esbuild";
 import fs from "node:fs/promises";
+import { isExternal } from "../../scripts/esbuild-module-check.mjs";
 
 (async () => {
     const packageJson = JSON.parse(
@@ -27,7 +28,7 @@ import fs from "node:fs/promises";
     esbuild
         .build({
             ...commonConfig,
-            external: commonConfig.external.filter(dep => !new RegExp(packageJson.internalDependencies).exec(dep)),
+            external: commonConfig.external.filter(isExternal),
             format: "cjs",
             outExtension: { ".js": ".cjs" },
         })

--- a/packages/support-tables/build.js
+++ b/packages/support-tables/build.js
@@ -1,5 +1,6 @@
 import esbuild from "esbuild";
 import fs from "node:fs/promises";
+import { COMPILE_PKG_REGEXP } from "../unified-latex/build.js";
 
 (async () => {
     const packageJson = JSON.parse(
@@ -27,7 +28,7 @@ import fs from "node:fs/promises";
     esbuild
         .build({
             ...commonConfig,
-            external: commonConfig.external.filter(dep => !/unified|bail|is-plain-obj|trough|vfile.*|unist.*|hast.*|property-information|html-void-elements|.*-separated-tokens|.*entities.*|ccount|rehype*|string-width|strip-ansi|ansi-regex|supports-color|rehype|web-namespaces|zwitch/.exec(dep)),
+            external: commonConfig.external.filter(dep => !COMPILE_PKG_REGEXP.exec(dep)),
             format: "cjs",
             outExtension: { ".js": ".cjs" },
         })

--- a/packages/unified-latex-builder/build.js
+++ b/packages/unified-latex-builder/build.js
@@ -1,6 +1,5 @@
 import esbuild from "esbuild";
 import fs from "node:fs/promises";
-import { COMPILE_PKG_REGEXP } from "../unified-latex/build.js";
 
 (async () => {
     const packageJson = JSON.parse(
@@ -28,7 +27,7 @@ import { COMPILE_PKG_REGEXP } from "../unified-latex/build.js";
     esbuild
         .build({
             ...commonConfig,
-            external: commonConfig.external.filter(dep => !COMPILE_PKG_REGEXP.exec(dep)),
+            external: commonConfig.external.filter(dep => !new RegExp(packageJson.internalDependencies).exec(dep)),
             outfile: "./dist/index.cjs",
             format: "cjs",
         })

--- a/packages/unified-latex-builder/build.js
+++ b/packages/unified-latex-builder/build.js
@@ -1,6 +1,6 @@
 import esbuild from "esbuild";
 import fs from "node:fs/promises";
-import { isExternal } from "../../scripts/esbuild-module-check.mjs";
+import { isCjsPackage } from "../../scripts/esbuild-module-check.mjs";
 
 (async () => {
     const packageJson = JSON.parse(
@@ -28,7 +28,7 @@ import { isExternal } from "../../scripts/esbuild-module-check.mjs";
     esbuild
         .build({
             ...commonConfig,
-            external: commonConfig.external.filter(isExternal),
+            external: commonConfig.external.filter(isCjsPackage),
             outfile: "./dist/index.cjs",
             format: "cjs",
         })

--- a/packages/unified-latex-builder/build.js
+++ b/packages/unified-latex-builder/build.js
@@ -1,5 +1,6 @@
 import esbuild from "esbuild";
 import fs from "node:fs/promises";
+import { COMPILE_PKG_REGEXP } from "../unified-latex/build.js";
 
 (async () => {
     const packageJson = JSON.parse(
@@ -27,7 +28,7 @@ import fs from "node:fs/promises";
     esbuild
         .build({
             ...commonConfig,
-            external: commonConfig.external.filter(dep => !/unified|bail|is-plain-obj|trough|vfile.*|unist.*|hast.*|property-information|html-void-elements|.*-separated-tokens|.*entities.*|ccount|rehype*|string-width|strip-ansi|ansi-regex|supports-color|rehype|web-namespaces|zwitch/.exec(dep)),
+            external: commonConfig.external.filter(dep => !COMPILE_PKG_REGEXP.exec(dep)),
             outfile: "./dist/index.cjs",
             format: "cjs",
         })

--- a/packages/unified-latex-builder/build.js
+++ b/packages/unified-latex-builder/build.js
@@ -1,5 +1,6 @@
 import esbuild from "esbuild";
 import fs from "node:fs/promises";
+import { isExternal } from "../../scripts/esbuild-module-check.mjs";
 
 (async () => {
     const packageJson = JSON.parse(
@@ -27,7 +28,7 @@ import fs from "node:fs/promises";
     esbuild
         .build({
             ...commonConfig,
-            external: commonConfig.external.filter(dep => !new RegExp(packageJson.internalDependencies).exec(dep)),
+            external: commonConfig.external.filter(isExternal),
             outfile: "./dist/index.cjs",
             format: "cjs",
         })

--- a/packages/unified-latex-builder/build.js
+++ b/packages/unified-latex-builder/build.js
@@ -27,6 +27,7 @@ import fs from "node:fs/promises";
     esbuild
         .build({
             ...commonConfig,
+            external: commonConfig.external.filter(dep => !/unified|bail|is-plain-obj|trough|vfile.*|unist.*|hast.*|property-information|html-void-elements|.*-separated-tokens|.*entities.*|ccount|rehype*|string-width|strip-ansi|ansi-regex|supports-color|rehype|web-namespaces|zwitch/.exec(dep)),
             outfile: "./dist/index.cjs",
             format: "cjs",
         })

--- a/packages/unified-latex-cli/build.js
+++ b/packages/unified-latex-cli/build.js
@@ -1,6 +1,5 @@
 import esbuild from "esbuild";
 import fs from "node:fs/promises";
-import { COMPILE_PKG_REGEXP } from "../unified-latex/build.js";
 
 (async () => {
     const packageJson = JSON.parse(
@@ -33,7 +32,7 @@ import { COMPILE_PKG_REGEXP } from "../unified-latex/build.js";
     esbuild
         .build({
             ...commonConfig,
-            external: commonConfig.external.filter(dep => !COMPILE_PKG_REGEXP.exec(dep)),
+            external: commonConfig.external.filter(dep => !new RegExp(packageJson.internalDependencies).exec(dep)),
             outfile: "./dist/index.cjs",
             format: "cjs",
         })

--- a/packages/unified-latex-cli/build.js
+++ b/packages/unified-latex-cli/build.js
@@ -32,6 +32,7 @@ import fs from "node:fs/promises";
     esbuild
         .build({
             ...commonConfig,
+            external: commonConfig.external.filter(dep => !/unified|bail|is-plain-obj|trough|vfile.*|unist.*|hast.*|property-information|html-void-elements|.*-separated-tokens|.*entities.*|ccount|rehype*|string-width|strip-ansi|ansi-regex|supports-color|rehype|web-namespaces|zwitch/.exec(dep)),
             outfile: "./dist/index.cjs",
             format: "cjs",
         })

--- a/packages/unified-latex-cli/build.js
+++ b/packages/unified-latex-cli/build.js
@@ -1,5 +1,6 @@
 import esbuild from "esbuild";
 import fs from "node:fs/promises";
+import { COMPILE_PKG_REGEXP } from "../unified-latex/build.js";
 
 (async () => {
     const packageJson = JSON.parse(
@@ -32,7 +33,7 @@ import fs from "node:fs/promises";
     esbuild
         .build({
             ...commonConfig,
-            external: commonConfig.external.filter(dep => !/unified|bail|is-plain-obj|trough|vfile.*|unist.*|hast.*|property-information|html-void-elements|.*-separated-tokens|.*entities.*|ccount|rehype*|string-width|strip-ansi|ansi-regex|supports-color|rehype|web-namespaces|zwitch/.exec(dep)),
+            external: commonConfig.external.filter(dep => !COMPILE_PKG_REGEXP.exec(dep)),
             outfile: "./dist/index.cjs",
             format: "cjs",
         })

--- a/packages/unified-latex-cli/build.js
+++ b/packages/unified-latex-cli/build.js
@@ -28,16 +28,6 @@ import fs from "node:fs/promises";
     // Build the ESM
     esbuild.build(commonConfig).catch(() => process.exit(1));
 
-    // Build a CommonJS version as well
-    esbuild
-        .build({
-            ...commonConfig,
-            external: commonConfig.external.filter(dep => !new RegExp(packageJson.internalDependencies).exec(dep)),
-            outfile: "./dist/index.cjs",
-            format: "cjs",
-        })
-        .catch(() => process.exit(1));
-
     // Build a standalone version as well
     esbuild
         .build({

--- a/packages/unified-latex-ctan/build.js
+++ b/packages/unified-latex-ctan/build.js
@@ -1,6 +1,7 @@
 import esbuild from "esbuild";
 import fs from "node:fs/promises";
 import glob from "glob";
+import { isExternal } from "../../scripts/esbuild-module-check.mjs";
 
 (async () => {
     const packageJson = JSON.parse(
@@ -31,7 +32,7 @@ import glob from "glob";
     esbuild
         .build({
             ...commonConfig,
-            external: commonConfig.external.filter(dep => !new RegExp(packageJson.internalDependencies).exec(dep)),
+            external: commonConfig.external.filter(isExternal),
             format: "cjs",
             outExtension: { ".js": ".cjs" },
         })

--- a/packages/unified-latex-ctan/build.js
+++ b/packages/unified-latex-ctan/build.js
@@ -1,7 +1,7 @@
 import esbuild from "esbuild";
 import fs from "node:fs/promises";
 import glob from "glob";
-import { isExternal } from "../../scripts/esbuild-module-check.mjs";
+import { isCjsPackage } from "../../scripts/esbuild-module-check.mjs";
 
 (async () => {
     const packageJson = JSON.parse(
@@ -32,7 +32,7 @@ import { isExternal } from "../../scripts/esbuild-module-check.mjs";
     esbuild
         .build({
             ...commonConfig,
-            external: commonConfig.external.filter(isExternal),
+            external: commonConfig.external.filter(isCjsPackage),
             format: "cjs",
             outExtension: { ".js": ".cjs" },
         })

--- a/packages/unified-latex-ctan/build.js
+++ b/packages/unified-latex-ctan/build.js
@@ -31,6 +31,7 @@ import glob from "glob";
     esbuild
         .build({
             ...commonConfig,
+            external: commonConfig.external.filter(dep => !/unified|bail|is-plain-obj|trough|vfile.*|unist.*|hast.*|property-information|html-void-elements|.*-separated-tokens|.*entities.*|ccount|rehype*|string-width|strip-ansi|ansi-regex|supports-color|rehype|web-namespaces|zwitch/.exec(dep)),
             format: "cjs",
             outExtension: { ".js": ".cjs" },
         })

--- a/packages/unified-latex-ctan/build.js
+++ b/packages/unified-latex-ctan/build.js
@@ -1,7 +1,6 @@
 import esbuild from "esbuild";
 import fs from "node:fs/promises";
 import glob from "glob";
-import { COMPILE_PKG_REGEXP } from "../unified-latex/build.js";
 
 (async () => {
     const packageJson = JSON.parse(
@@ -32,7 +31,7 @@ import { COMPILE_PKG_REGEXP } from "../unified-latex/build.js";
     esbuild
         .build({
             ...commonConfig,
-            external: commonConfig.external.filter(dep => !COMPILE_PKG_REGEXP.exec(dep)),
+            external: commonConfig.external.filter(dep => !new RegExp(packageJson.internalDependencies).exec(dep)),
             format: "cjs",
             outExtension: { ".js": ".cjs" },
         })

--- a/packages/unified-latex-ctan/build.js
+++ b/packages/unified-latex-ctan/build.js
@@ -1,6 +1,7 @@
 import esbuild from "esbuild";
 import fs from "node:fs/promises";
 import glob from "glob";
+import { COMPILE_PKG_REGEXP } from "../unified-latex/build.js";
 
 (async () => {
     const packageJson = JSON.parse(
@@ -31,7 +32,7 @@ import glob from "glob";
     esbuild
         .build({
             ...commonConfig,
-            external: commonConfig.external.filter(dep => !/unified|bail|is-plain-obj|trough|vfile.*|unist.*|hast.*|property-information|html-void-elements|.*-separated-tokens|.*entities.*|ccount|rehype*|string-width|strip-ansi|ansi-regex|supports-color|rehype|web-namespaces|zwitch/.exec(dep)),
+            external: commonConfig.external.filter(dep => !COMPILE_PKG_REGEXP.exec(dep)),
             format: "cjs",
             outExtension: { ".js": ".cjs" },
         })

--- a/packages/unified-latex-lint/build.js
+++ b/packages/unified-latex-lint/build.js
@@ -1,6 +1,7 @@
 import esbuild from "esbuild";
 import fs from "node:fs/promises";
 import glob from "glob";
+import { isExternal } from "../../scripts/esbuild-module-check.mjs";
 
 (async () => {
     const packageJson = JSON.parse(
@@ -31,7 +32,7 @@ import glob from "glob";
     esbuild
         .build({
             ...commonConfig,
-            external: commonConfig.external.filter(dep => !new RegExp(packageJson.internalDependencies).exec(dep)),
+            external: commonConfig.external.filter(isExternal),
             format: "cjs",
             outExtension: { ".js": ".cjs" },
         })

--- a/packages/unified-latex-lint/build.js
+++ b/packages/unified-latex-lint/build.js
@@ -1,7 +1,7 @@
 import esbuild from "esbuild";
 import fs from "node:fs/promises";
 import glob from "glob";
-import { isExternal } from "../../scripts/esbuild-module-check.mjs";
+import { isCjsPackage } from "../../scripts/esbuild-module-check.mjs";
 
 (async () => {
     const packageJson = JSON.parse(
@@ -32,7 +32,7 @@ import { isExternal } from "../../scripts/esbuild-module-check.mjs";
     esbuild
         .build({
             ...commonConfig,
-            external: commonConfig.external.filter(isExternal),
+            external: commonConfig.external.filter(isCjsPackage),
             format: "cjs",
             outExtension: { ".js": ".cjs" },
         })

--- a/packages/unified-latex-lint/build.js
+++ b/packages/unified-latex-lint/build.js
@@ -31,6 +31,7 @@ import glob from "glob";
     esbuild
         .build({
             ...commonConfig,
+            external: commonConfig.external.filter(dep => !/unified|bail|is-plain-obj|trough|vfile.*|unist.*|hast.*|property-information|html-void-elements|.*-separated-tokens|.*entities.*|ccount|rehype*|string-width|strip-ansi|ansi-regex|supports-color|rehype|web-namespaces|zwitch/.exec(dep)),
             format: "cjs",
             outExtension: { ".js": ".cjs" },
         })

--- a/packages/unified-latex-lint/build.js
+++ b/packages/unified-latex-lint/build.js
@@ -1,7 +1,6 @@
 import esbuild from "esbuild";
 import fs from "node:fs/promises";
 import glob from "glob";
-import { COMPILE_PKG_REGEXP } from "../unified-latex/build.js";
 
 (async () => {
     const packageJson = JSON.parse(
@@ -32,7 +31,7 @@ import { COMPILE_PKG_REGEXP } from "../unified-latex/build.js";
     esbuild
         .build({
             ...commonConfig,
-            external: commonConfig.external.filter(dep => !COMPILE_PKG_REGEXP.exec(dep)),
+            external: commonConfig.external.filter(dep => !new RegExp(packageJson.internalDependencies).exec(dep)),
             format: "cjs",
             outExtension: { ".js": ".cjs" },
         })

--- a/packages/unified-latex-lint/build.js
+++ b/packages/unified-latex-lint/build.js
@@ -1,6 +1,7 @@
 import esbuild from "esbuild";
 import fs from "node:fs/promises";
 import glob from "glob";
+import { COMPILE_PKG_REGEXP } from "../unified-latex/build.js";
 
 (async () => {
     const packageJson = JSON.parse(
@@ -31,7 +32,7 @@ import glob from "glob";
     esbuild
         .build({
             ...commonConfig,
-            external: commonConfig.external.filter(dep => !/unified|bail|is-plain-obj|trough|vfile.*|unist.*|hast.*|property-information|html-void-elements|.*-separated-tokens|.*entities.*|ccount|rehype*|string-width|strip-ansi|ansi-regex|supports-color|rehype|web-namespaces|zwitch/.exec(dep)),
+            external: commonConfig.external.filter(dep => !COMPILE_PKG_REGEXP.exec(dep)),
             format: "cjs",
             outExtension: { ".js": ".cjs" },
         })

--- a/packages/unified-latex-prettier/build.js
+++ b/packages/unified-latex-prettier/build.js
@@ -1,5 +1,6 @@
 import esbuild from "esbuild";
 import fs from "node:fs/promises";
+import { isExternal } from "../../scripts/esbuild-module-check.mjs";
 
 (async () => {
     const packageJson = JSON.parse(
@@ -31,7 +32,7 @@ import fs from "node:fs/promises";
     esbuild
         .build({
             ...commonConfig,
-            external: commonConfig.external.filter(dep => !new RegExp(packageJson.internalDependencies).exec(dep)),
+            external: commonConfig.external.filter(isExternal),
             outfile: "./dist/index.cjs",
             format: "cjs",
         })

--- a/packages/unified-latex-prettier/build.js
+++ b/packages/unified-latex-prettier/build.js
@@ -1,6 +1,5 @@
 import esbuild from "esbuild";
 import fs from "node:fs/promises";
-import { COMPILE_PKG_REGEXP } from "../unified-latex/build.js";
 
 (async () => {
     const packageJson = JSON.parse(
@@ -32,7 +31,7 @@ import { COMPILE_PKG_REGEXP } from "../unified-latex/build.js";
     esbuild
         .build({
             ...commonConfig,
-            external: commonConfig.external.filter(dep => !COMPILE_PKG_REGEXP.exec(dep)),
+            external: commonConfig.external.filter(dep => !new RegExp(packageJson.internalDependencies).exec(dep)),
             outfile: "./dist/index.cjs",
             format: "cjs",
         })

--- a/packages/unified-latex-prettier/build.js
+++ b/packages/unified-latex-prettier/build.js
@@ -1,5 +1,6 @@
 import esbuild from "esbuild";
 import fs from "node:fs/promises";
+import { COMPILE_PKG_REGEXP } from "../unified-latex/build.js";
 
 (async () => {
     const packageJson = JSON.parse(
@@ -31,7 +32,7 @@ import fs from "node:fs/promises";
     esbuild
         .build({
             ...commonConfig,
-            external: commonConfig.external.filter(dep => !/unified|bail|is-plain-obj|trough|vfile.*|unist.*|hast.*|property-information|html-void-elements|.*-separated-tokens|.*entities.*|ccount|rehype*|string-width|strip-ansi|ansi-regex|supports-color|rehype|web-namespaces|zwitch/.exec(dep)),
+            external: commonConfig.external.filter(dep => !COMPILE_PKG_REGEXP.exec(dep)),
             outfile: "./dist/index.cjs",
             format: "cjs",
         })

--- a/packages/unified-latex-prettier/build.js
+++ b/packages/unified-latex-prettier/build.js
@@ -31,6 +31,7 @@ import fs from "node:fs/promises";
     esbuild
         .build({
             ...commonConfig,
+            external: commonConfig.external.filter(dep => !/unified|bail|is-plain-obj|trough|vfile.*|unist.*|hast.*|property-information|html-void-elements|.*-separated-tokens|.*entities.*|ccount|rehype*|string-width|strip-ansi|ansi-regex|supports-color|rehype|web-namespaces|zwitch/.exec(dep)),
             outfile: "./dist/index.cjs",
             format: "cjs",
         })

--- a/packages/unified-latex-prettier/build.js
+++ b/packages/unified-latex-prettier/build.js
@@ -1,6 +1,6 @@
 import esbuild from "esbuild";
 import fs from "node:fs/promises";
-import { isExternal } from "../../scripts/esbuild-module-check.mjs";
+import { isCjsPackage } from "../../scripts/esbuild-module-check.mjs";
 
 (async () => {
     const packageJson = JSON.parse(
@@ -32,7 +32,7 @@ import { isExternal } from "../../scripts/esbuild-module-check.mjs";
     esbuild
         .build({
             ...commonConfig,
-            external: commonConfig.external.filter(isExternal),
+            external: commonConfig.external.filter(isCjsPackage),
             outfile: "./dist/index.cjs",
             format: "cjs",
         })

--- a/packages/unified-latex-to-hast/build.js
+++ b/packages/unified-latex-to-hast/build.js
@@ -1,6 +1,5 @@
 import esbuild from "esbuild";
 import fs from "node:fs/promises";
-import { COMPILE_PKG_REGEXP } from "../unified-latex/build.js";
 
 (async () => {
     const packageJson = JSON.parse(
@@ -28,7 +27,7 @@ import { COMPILE_PKG_REGEXP } from "../unified-latex/build.js";
     esbuild
         .build({
             ...commonConfig,
-            external: commonConfig.external.filter(dep => !COMPILE_PKG_REGEXP.exec(dep)),
+            external: commonConfig.external.filter(dep => !new RegExp(packageJson.internalDependencies).exec(dep)),
             outfile: "./dist/index.cjs",
             format: "cjs",
         })

--- a/packages/unified-latex-to-hast/build.js
+++ b/packages/unified-latex-to-hast/build.js
@@ -1,6 +1,6 @@
 import esbuild from "esbuild";
 import fs from "node:fs/promises";
-import { isExternal } from "../../scripts/esbuild-module-check.mjs";
+import { isCjsPackage } from "../../scripts/esbuild-module-check.mjs";
 
 (async () => {
     const packageJson = JSON.parse(
@@ -28,7 +28,7 @@ import { isExternal } from "../../scripts/esbuild-module-check.mjs";
     esbuild
         .build({
             ...commonConfig,
-            external: commonConfig.external.filter(isExternal),
+            external: commonConfig.external.filter(isCjsPackage),
             outfile: "./dist/index.cjs",
             format: "cjs",
         })

--- a/packages/unified-latex-to-hast/build.js
+++ b/packages/unified-latex-to-hast/build.js
@@ -1,5 +1,6 @@
 import esbuild from "esbuild";
 import fs from "node:fs/promises";
+import { COMPILE_PKG_REGEXP } from "../unified-latex/build.js";
 
 (async () => {
     const packageJson = JSON.parse(
@@ -27,7 +28,7 @@ import fs from "node:fs/promises";
     esbuild
         .build({
             ...commonConfig,
-            external: commonConfig.external.filter(dep => !/unified|bail|is-plain-obj|trough|vfile.*|unist.*|hast.*|property-information|html-void-elements|.*-separated-tokens|.*entities.*|ccount|rehype*|string-width|strip-ansi|ansi-regex|supports-color|rehype|web-namespaces|zwitch/.exec(dep)),
+            external: commonConfig.external.filter(dep => !COMPILE_PKG_REGEXP.exec(dep)),
             outfile: "./dist/index.cjs",
             format: "cjs",
         })

--- a/packages/unified-latex-to-hast/build.js
+++ b/packages/unified-latex-to-hast/build.js
@@ -1,5 +1,6 @@
 import esbuild from "esbuild";
 import fs from "node:fs/promises";
+import { isExternal } from "../../scripts/esbuild-module-check.mjs";
 
 (async () => {
     const packageJson = JSON.parse(
@@ -27,7 +28,7 @@ import fs from "node:fs/promises";
     esbuild
         .build({
             ...commonConfig,
-            external: commonConfig.external.filter(dep => !new RegExp(packageJson.internalDependencies).exec(dep)),
+            external: commonConfig.external.filter(isExternal),
             outfile: "./dist/index.cjs",
             format: "cjs",
         })

--- a/packages/unified-latex-to-hast/build.js
+++ b/packages/unified-latex-to-hast/build.js
@@ -27,6 +27,7 @@ import fs from "node:fs/promises";
     esbuild
         .build({
             ...commonConfig,
+            external: commonConfig.external.filter(dep => !/unified|bail|is-plain-obj|trough|vfile.*|unist.*|hast.*|property-information|html-void-elements|.*-separated-tokens|.*entities.*|ccount|rehype*|string-width|strip-ansi|ansi-regex|supports-color|rehype|web-namespaces|zwitch/.exec(dep)),
             outfile: "./dist/index.cjs",
             format: "cjs",
         })

--- a/packages/unified-latex-util-align/build.js
+++ b/packages/unified-latex-util-align/build.js
@@ -1,6 +1,5 @@
 import esbuild from "esbuild";
 import fs from "node:fs/promises";
-import { COMPILE_PKG_REGEXP } from "../unified-latex/build.js";
 
 (async () => {
     const packageJson = JSON.parse(
@@ -28,7 +27,7 @@ import { COMPILE_PKG_REGEXP } from "../unified-latex/build.js";
     esbuild
         .build({
             ...commonConfig,
-            external: commonConfig.external.filter(dep => !COMPILE_PKG_REGEXP.exec(dep)),
+            external: commonConfig.external.filter(dep => !new RegExp(packageJson.internalDependencies).exec(dep)),
             outfile: "./dist/index.cjs",
             format: "cjs",
         })

--- a/packages/unified-latex-util-align/build.js
+++ b/packages/unified-latex-util-align/build.js
@@ -1,6 +1,6 @@
 import esbuild from "esbuild";
 import fs from "node:fs/promises";
-import { isExternal } from "../../scripts/esbuild-module-check.mjs";
+import { isCjsPackage } from "../../scripts/esbuild-module-check.mjs";
 
 (async () => {
     const packageJson = JSON.parse(
@@ -28,7 +28,7 @@ import { isExternal } from "../../scripts/esbuild-module-check.mjs";
     esbuild
         .build({
             ...commonConfig,
-            external: commonConfig.external.filter(isExternal),
+            external: commonConfig.external.filter(isCjsPackage),
             outfile: "./dist/index.cjs",
             format: "cjs",
         })

--- a/packages/unified-latex-util-align/build.js
+++ b/packages/unified-latex-util-align/build.js
@@ -1,5 +1,6 @@
 import esbuild from "esbuild";
 import fs from "node:fs/promises";
+import { COMPILE_PKG_REGEXP } from "../unified-latex/build.js";
 
 (async () => {
     const packageJson = JSON.parse(
@@ -27,7 +28,7 @@ import fs from "node:fs/promises";
     esbuild
         .build({
             ...commonConfig,
-            external: commonConfig.external.filter(dep => !/unified|bail|is-plain-obj|trough|vfile.*|unist.*|hast.*|property-information|html-void-elements|.*-separated-tokens|.*entities.*|ccount|rehype*|string-width|strip-ansi|ansi-regex|supports-color|rehype|web-namespaces|zwitch/.exec(dep)),
+            external: commonConfig.external.filter(dep => !COMPILE_PKG_REGEXP.exec(dep)),
             outfile: "./dist/index.cjs",
             format: "cjs",
         })

--- a/packages/unified-latex-util-align/build.js
+++ b/packages/unified-latex-util-align/build.js
@@ -1,5 +1,6 @@
 import esbuild from "esbuild";
 import fs from "node:fs/promises";
+import { isExternal } from "../../scripts/esbuild-module-check.mjs";
 
 (async () => {
     const packageJson = JSON.parse(
@@ -27,7 +28,7 @@ import fs from "node:fs/promises";
     esbuild
         .build({
             ...commonConfig,
-            external: commonConfig.external.filter(dep => !new RegExp(packageJson.internalDependencies).exec(dep)),
+            external: commonConfig.external.filter(isExternal),
             outfile: "./dist/index.cjs",
             format: "cjs",
         })

--- a/packages/unified-latex-util-align/build.js
+++ b/packages/unified-latex-util-align/build.js
@@ -27,6 +27,7 @@ import fs from "node:fs/promises";
     esbuild
         .build({
             ...commonConfig,
+            external: commonConfig.external.filter(dep => !/unified|bail|is-plain-obj|trough|vfile.*|unist.*|hast.*|property-information|html-void-elements|.*-separated-tokens|.*entities.*|ccount|rehype*|string-width|strip-ansi|ansi-regex|supports-color|rehype|web-namespaces|zwitch/.exec(dep)),
             outfile: "./dist/index.cjs",
             format: "cjs",
         })

--- a/packages/unified-latex-util-argspec/build.js
+++ b/packages/unified-latex-util-argspec/build.js
@@ -27,6 +27,7 @@ import fs from "node:fs/promises";
     esbuild
         .build({
             ...commonConfig,
+            external: commonConfig.external.filter(dep => !new RegExp(packageJson.internalDependencies).exec(dep)),
             outfile: "./dist/index.cjs",
             format: "cjs",
         })

--- a/packages/unified-latex-util-argspec/build.js
+++ b/packages/unified-latex-util-argspec/build.js
@@ -1,6 +1,6 @@
 import esbuild from "esbuild";
 import fs from "node:fs/promises";
-import { isExternal } from "../../scripts/esbuild-module-check.mjs";
+import { isCjsPackage } from "../../scripts/esbuild-module-check.mjs";
 
 (async () => {
     const packageJson = JSON.parse(
@@ -28,7 +28,7 @@ import { isExternal } from "../../scripts/esbuild-module-check.mjs";
     esbuild
         .build({
             ...commonConfig,
-            external: commonConfig.external.filter(isExternal),
+            external: commonConfig.external.filter(isCjsPackage),
             outfile: "./dist/index.cjs",
             format: "cjs",
         })

--- a/packages/unified-latex-util-argspec/build.js
+++ b/packages/unified-latex-util-argspec/build.js
@@ -1,5 +1,6 @@
 import esbuild from "esbuild";
 import fs from "node:fs/promises";
+import { isExternal } from "../../scripts/esbuild-module-check.mjs";
 
 (async () => {
     const packageJson = JSON.parse(
@@ -27,7 +28,7 @@ import fs from "node:fs/promises";
     esbuild
         .build({
             ...commonConfig,
-            external: commonConfig.external.filter(dep => !new RegExp(packageJson.internalDependencies).exec(dep)),
+            external: commonConfig.external.filter(isExternal),
             outfile: "./dist/index.cjs",
             format: "cjs",
         })

--- a/packages/unified-latex-util-arguments/build.js
+++ b/packages/unified-latex-util-arguments/build.js
@@ -1,6 +1,5 @@
 import esbuild from "esbuild";
 import fs from "node:fs/promises";
-import { COMPILE_PKG_REGEXP } from "../unified-latex/build.js";
 
 (async () => {
     const packageJson = JSON.parse(
@@ -28,7 +27,7 @@ import { COMPILE_PKG_REGEXP } from "../unified-latex/build.js";
     esbuild
         .build({
             ...commonConfig,
-            external: commonConfig.external.filter(dep => !COMPILE_PKG_REGEXP.exec(dep)),
+            external: commonConfig.external.filter(dep => !new RegExp(packageJson.internalDependencies).exec(dep)),
             outfile: "./dist/index.cjs",
             format: "cjs",
         })

--- a/packages/unified-latex-util-arguments/build.js
+++ b/packages/unified-latex-util-arguments/build.js
@@ -1,6 +1,6 @@
 import esbuild from "esbuild";
 import fs from "node:fs/promises";
-import { isExternal } from "../../scripts/esbuild-module-check.mjs";
+import { isCjsPackage } from "../../scripts/esbuild-module-check.mjs";
 
 (async () => {
     const packageJson = JSON.parse(
@@ -28,7 +28,7 @@ import { isExternal } from "../../scripts/esbuild-module-check.mjs";
     esbuild
         .build({
             ...commonConfig,
-            external: commonConfig.external.filter(isExternal),
+            external: commonConfig.external.filter(isCjsPackage),
             outfile: "./dist/index.cjs",
             format: "cjs",
         })

--- a/packages/unified-latex-util-arguments/build.js
+++ b/packages/unified-latex-util-arguments/build.js
@@ -1,5 +1,6 @@
 import esbuild from "esbuild";
 import fs from "node:fs/promises";
+import { COMPILE_PKG_REGEXP } from "../unified-latex/build.js";
 
 (async () => {
     const packageJson = JSON.parse(
@@ -27,7 +28,7 @@ import fs from "node:fs/promises";
     esbuild
         .build({
             ...commonConfig,
-            external: commonConfig.external.filter(dep => !/unified|bail|is-plain-obj|trough|vfile.*|unist.*|hast.*|property-information|html-void-elements|.*-separated-tokens|.*entities.*|ccount|rehype*|string-width|strip-ansi|ansi-regex|supports-color|rehype|web-namespaces|zwitch/.exec(dep)),
+            external: commonConfig.external.filter(dep => !COMPILE_PKG_REGEXP.exec(dep)),
             outfile: "./dist/index.cjs",
             format: "cjs",
         })

--- a/packages/unified-latex-util-arguments/build.js
+++ b/packages/unified-latex-util-arguments/build.js
@@ -1,5 +1,6 @@
 import esbuild from "esbuild";
 import fs from "node:fs/promises";
+import { isExternal } from "../../scripts/esbuild-module-check.mjs";
 
 (async () => {
     const packageJson = JSON.parse(
@@ -27,7 +28,7 @@ import fs from "node:fs/promises";
     esbuild
         .build({
             ...commonConfig,
-            external: commonConfig.external.filter(dep => !new RegExp(packageJson.internalDependencies).exec(dep)),
+            external: commonConfig.external.filter(isExternal),
             outfile: "./dist/index.cjs",
             format: "cjs",
         })

--- a/packages/unified-latex-util-arguments/build.js
+++ b/packages/unified-latex-util-arguments/build.js
@@ -27,6 +27,7 @@ import fs from "node:fs/promises";
     esbuild
         .build({
             ...commonConfig,
+            external: commonConfig.external.filter(dep => !/unified|bail|is-plain-obj|trough|vfile.*|unist.*|hast.*|property-information|html-void-elements|.*-separated-tokens|.*entities.*|ccount|rehype*|string-width|strip-ansi|ansi-regex|supports-color|rehype|web-namespaces|zwitch/.exec(dep)),
             outfile: "./dist/index.cjs",
             format: "cjs",
         })

--- a/packages/unified-latex-util-catcode/build.js
+++ b/packages/unified-latex-util-catcode/build.js
@@ -1,6 +1,5 @@
 import esbuild from "esbuild";
 import fs from "node:fs/promises";
-import { COMPILE_PKG_REGEXP } from "../unified-latex/build.js";
 
 (async () => {
     const packageJson = JSON.parse(
@@ -28,7 +27,7 @@ import { COMPILE_PKG_REGEXP } from "../unified-latex/build.js";
     esbuild
         .build({
             ...commonConfig,
-            external: commonConfig.external.filter(dep => !COMPILE_PKG_REGEXP.exec(dep)),
+            external: commonConfig.external.filter(dep => !new RegExp(packageJson.internalDependencies).exec(dep)),
             outfile: "./dist/index.cjs",
             format: "cjs",
         })

--- a/packages/unified-latex-util-catcode/build.js
+++ b/packages/unified-latex-util-catcode/build.js
@@ -1,6 +1,6 @@
 import esbuild from "esbuild";
 import fs from "node:fs/promises";
-import { isExternal } from "../../scripts/esbuild-module-check.mjs";
+import { isCjsPackage } from "../../scripts/esbuild-module-check.mjs";
 
 (async () => {
     const packageJson = JSON.parse(
@@ -28,7 +28,7 @@ import { isExternal } from "../../scripts/esbuild-module-check.mjs";
     esbuild
         .build({
             ...commonConfig,
-            external: commonConfig.external.filter(isExternal),
+            external: commonConfig.external.filter(isCjsPackage),
             outfile: "./dist/index.cjs",
             format: "cjs",
         })

--- a/packages/unified-latex-util-catcode/build.js
+++ b/packages/unified-latex-util-catcode/build.js
@@ -1,5 +1,6 @@
 import esbuild from "esbuild";
 import fs from "node:fs/promises";
+import { COMPILE_PKG_REGEXP } from "../unified-latex/build.js";
 
 (async () => {
     const packageJson = JSON.parse(
@@ -27,7 +28,7 @@ import fs from "node:fs/promises";
     esbuild
         .build({
             ...commonConfig,
-            external: commonConfig.external.filter(dep => !/unified|bail|is-plain-obj|trough|vfile.*|unist.*|hast.*|property-information|html-void-elements|.*-separated-tokens|.*entities.*|ccount|rehype*|string-width|strip-ansi|ansi-regex|supports-color|rehype|web-namespaces|zwitch/.exec(dep)),
+            external: commonConfig.external.filter(dep => !COMPILE_PKG_REGEXP.exec(dep)),
             outfile: "./dist/index.cjs",
             format: "cjs",
         })

--- a/packages/unified-latex-util-catcode/build.js
+++ b/packages/unified-latex-util-catcode/build.js
@@ -1,5 +1,6 @@
 import esbuild from "esbuild";
 import fs from "node:fs/promises";
+import { isExternal } from "../../scripts/esbuild-module-check.mjs";
 
 (async () => {
     const packageJson = JSON.parse(
@@ -27,7 +28,7 @@ import fs from "node:fs/promises";
     esbuild
         .build({
             ...commonConfig,
-            external: commonConfig.external.filter(dep => !new RegExp(packageJson.internalDependencies).exec(dep)),
+            external: commonConfig.external.filter(isExternal),
             outfile: "./dist/index.cjs",
             format: "cjs",
         })

--- a/packages/unified-latex-util-catcode/build.js
+++ b/packages/unified-latex-util-catcode/build.js
@@ -27,6 +27,7 @@ import fs from "node:fs/promises";
     esbuild
         .build({
             ...commonConfig,
+            external: commonConfig.external.filter(dep => !/unified|bail|is-plain-obj|trough|vfile.*|unist.*|hast.*|property-information|html-void-elements|.*-separated-tokens|.*entities.*|ccount|rehype*|string-width|strip-ansi|ansi-regex|supports-color|rehype|web-namespaces|zwitch/.exec(dep)),
             outfile: "./dist/index.cjs",
             format: "cjs",
         })

--- a/packages/unified-latex-util-comments/build.js
+++ b/packages/unified-latex-util-comments/build.js
@@ -1,6 +1,5 @@
 import esbuild from "esbuild";
 import fs from "node:fs/promises";
-import { COMPILE_PKG_REGEXP } from "../unified-latex/build.js";
 
 (async () => {
     const packageJson = JSON.parse(
@@ -28,7 +27,7 @@ import { COMPILE_PKG_REGEXP } from "../unified-latex/build.js";
     esbuild
         .build({
             ...commonConfig,
-            external: commonConfig.external.filter(dep => !COMPILE_PKG_REGEXP.exec(dep)),
+            external: commonConfig.external.filter(dep => !new RegExp(packageJson.internalDependencies).exec(dep)),
             outfile: "./dist/index.cjs",
             format: "cjs",
         })

--- a/packages/unified-latex-util-comments/build.js
+++ b/packages/unified-latex-util-comments/build.js
@@ -1,6 +1,6 @@
 import esbuild from "esbuild";
 import fs from "node:fs/promises";
-import { isExternal } from "../../scripts/esbuild-module-check.mjs";
+import { isCjsPackage } from "../../scripts/esbuild-module-check.mjs";
 
 (async () => {
     const packageJson = JSON.parse(
@@ -28,7 +28,7 @@ import { isExternal } from "../../scripts/esbuild-module-check.mjs";
     esbuild
         .build({
             ...commonConfig,
-            external: commonConfig.external.filter(isExternal),
+            external: commonConfig.external.filter(isCjsPackage),
             outfile: "./dist/index.cjs",
             format: "cjs",
         })

--- a/packages/unified-latex-util-comments/build.js
+++ b/packages/unified-latex-util-comments/build.js
@@ -1,5 +1,6 @@
 import esbuild from "esbuild";
 import fs from "node:fs/promises";
+import { COMPILE_PKG_REGEXP } from "../unified-latex/build.js";
 
 (async () => {
     const packageJson = JSON.parse(
@@ -27,7 +28,7 @@ import fs from "node:fs/promises";
     esbuild
         .build({
             ...commonConfig,
-            external: commonConfig.external.filter(dep => !/unified|bail|is-plain-obj|trough|vfile.*|unist.*|hast.*|property-information|html-void-elements|.*-separated-tokens|.*entities.*|ccount|rehype*|string-width|strip-ansi|ansi-regex|supports-color|rehype|web-namespaces|zwitch/.exec(dep)),
+            external: commonConfig.external.filter(dep => !COMPILE_PKG_REGEXP.exec(dep)),
             outfile: "./dist/index.cjs",
             format: "cjs",
         })

--- a/packages/unified-latex-util-comments/build.js
+++ b/packages/unified-latex-util-comments/build.js
@@ -1,5 +1,6 @@
 import esbuild from "esbuild";
 import fs from "node:fs/promises";
+import { isExternal } from "../../scripts/esbuild-module-check.mjs";
 
 (async () => {
     const packageJson = JSON.parse(
@@ -27,7 +28,7 @@ import fs from "node:fs/promises";
     esbuild
         .build({
             ...commonConfig,
-            external: commonConfig.external.filter(dep => !new RegExp(packageJson.internalDependencies).exec(dep)),
+            external: commonConfig.external.filter(isExternal),
             outfile: "./dist/index.cjs",
             format: "cjs",
         })

--- a/packages/unified-latex-util-comments/build.js
+++ b/packages/unified-latex-util-comments/build.js
@@ -27,6 +27,7 @@ import fs from "node:fs/promises";
     esbuild
         .build({
             ...commonConfig,
+            external: commonConfig.external.filter(dep => !/unified|bail|is-plain-obj|trough|vfile.*|unist.*|hast.*|property-information|html-void-elements|.*-separated-tokens|.*entities.*|ccount|rehype*|string-width|strip-ansi|ansi-regex|supports-color|rehype|web-namespaces|zwitch/.exec(dep)),
             outfile: "./dist/index.cjs",
             format: "cjs",
         })

--- a/packages/unified-latex-util-environments/build.js
+++ b/packages/unified-latex-util-environments/build.js
@@ -1,6 +1,5 @@
 import esbuild from "esbuild";
 import fs from "node:fs/promises";
-import { COMPILE_PKG_REGEXP } from "../unified-latex/build.js";
 
 (async () => {
     const packageJson = JSON.parse(
@@ -28,7 +27,7 @@ import { COMPILE_PKG_REGEXP } from "../unified-latex/build.js";
     esbuild
         .build({
             ...commonConfig,
-            external: commonConfig.external.filter(dep => !COMPILE_PKG_REGEXP.exec(dep)),
+            external: commonConfig.external.filter(dep => !new RegExp(packageJson.internalDependencies).exec(dep)),
             outfile: "./dist/index.cjs",
             format: "cjs",
         })

--- a/packages/unified-latex-util-environments/build.js
+++ b/packages/unified-latex-util-environments/build.js
@@ -1,6 +1,6 @@
 import esbuild from "esbuild";
 import fs from "node:fs/promises";
-import { isExternal } from "../../scripts/esbuild-module-check.mjs";
+import { isCjsPackage } from "../../scripts/esbuild-module-check.mjs";
 
 (async () => {
     const packageJson = JSON.parse(
@@ -28,7 +28,7 @@ import { isExternal } from "../../scripts/esbuild-module-check.mjs";
     esbuild
         .build({
             ...commonConfig,
-            external: commonConfig.external.filter(isExternal),
+            external: commonConfig.external.filter(isCjsPackage),
             outfile: "./dist/index.cjs",
             format: "cjs",
         })

--- a/packages/unified-latex-util-environments/build.js
+++ b/packages/unified-latex-util-environments/build.js
@@ -1,5 +1,6 @@
 import esbuild from "esbuild";
 import fs from "node:fs/promises";
+import { COMPILE_PKG_REGEXP } from "../unified-latex/build.js";
 
 (async () => {
     const packageJson = JSON.parse(
@@ -27,7 +28,7 @@ import fs from "node:fs/promises";
     esbuild
         .build({
             ...commonConfig,
-            external: commonConfig.external.filter(dep => !/unified|bail|is-plain-obj|trough|vfile.*|unist.*|hast.*|property-information|html-void-elements|.*-separated-tokens|.*entities.*|ccount|rehype*|string-width|strip-ansi|ansi-regex|supports-color|rehype|web-namespaces|zwitch/.exec(dep)),
+            external: commonConfig.external.filter(dep => !COMPILE_PKG_REGEXP.exec(dep)),
             outfile: "./dist/index.cjs",
             format: "cjs",
         })

--- a/packages/unified-latex-util-environments/build.js
+++ b/packages/unified-latex-util-environments/build.js
@@ -1,5 +1,6 @@
 import esbuild from "esbuild";
 import fs from "node:fs/promises";
+import { isExternal } from "../../scripts/esbuild-module-check.mjs";
 
 (async () => {
     const packageJson = JSON.parse(
@@ -27,7 +28,7 @@ import fs from "node:fs/promises";
     esbuild
         .build({
             ...commonConfig,
-            external: commonConfig.external.filter(dep => !new RegExp(packageJson.internalDependencies).exec(dep)),
+            external: commonConfig.external.filter(isExternal),
             outfile: "./dist/index.cjs",
             format: "cjs",
         })

--- a/packages/unified-latex-util-environments/build.js
+++ b/packages/unified-latex-util-environments/build.js
@@ -27,6 +27,7 @@ import fs from "node:fs/promises";
     esbuild
         .build({
             ...commonConfig,
+            external: commonConfig.external.filter(dep => !/unified|bail|is-plain-obj|trough|vfile.*|unist.*|hast.*|property-information|html-void-elements|.*-separated-tokens|.*entities.*|ccount|rehype*|string-width|strip-ansi|ansi-regex|supports-color|rehype|web-namespaces|zwitch/.exec(dep)),
             outfile: "./dist/index.cjs",
             format: "cjs",
         })

--- a/packages/unified-latex-util-glue/build.js
+++ b/packages/unified-latex-util-glue/build.js
@@ -1,6 +1,5 @@
 import esbuild from "esbuild";
 import fs from "node:fs/promises";
-import { COMPILE_PKG_REGEXP } from "../unified-latex/build.js";
 
 (async () => {
     const packageJson = JSON.parse(
@@ -28,7 +27,7 @@ import { COMPILE_PKG_REGEXP } from "../unified-latex/build.js";
     esbuild
         .build({
             ...commonConfig,
-            external: commonConfig.external.filter(dep => !COMPILE_PKG_REGEXP.exec(dep)),
+            external: commonConfig.external.filter(dep => !new RegExp(packageJson.internalDependencies).exec(dep)),
             outfile: "./dist/index.cjs",
             format: "cjs",
         })

--- a/packages/unified-latex-util-glue/build.js
+++ b/packages/unified-latex-util-glue/build.js
@@ -1,6 +1,6 @@
 import esbuild from "esbuild";
 import fs from "node:fs/promises";
-import { isExternal } from "../../scripts/esbuild-module-check.mjs";
+import { isCjsPackage } from "../../scripts/esbuild-module-check.mjs";
 
 (async () => {
     const packageJson = JSON.parse(
@@ -28,7 +28,7 @@ import { isExternal } from "../../scripts/esbuild-module-check.mjs";
     esbuild
         .build({
             ...commonConfig,
-            external: commonConfig.external.filter(isExternal),
+            external: commonConfig.external.filter(isCjsPackage),
             outfile: "./dist/index.cjs",
             format: "cjs",
         })

--- a/packages/unified-latex-util-glue/build.js
+++ b/packages/unified-latex-util-glue/build.js
@@ -1,5 +1,6 @@
 import esbuild from "esbuild";
 import fs from "node:fs/promises";
+import { COMPILE_PKG_REGEXP } from "../unified-latex/build.js";
 
 (async () => {
     const packageJson = JSON.parse(
@@ -27,7 +28,7 @@ import fs from "node:fs/promises";
     esbuild
         .build({
             ...commonConfig,
-            external: commonConfig.external.filter(dep => !/unified|bail|is-plain-obj|trough|vfile.*|unist.*|hast.*|property-information|html-void-elements|.*-separated-tokens|.*entities.*|ccount|rehype*|string-width|strip-ansi|ansi-regex|supports-color|rehype|web-namespaces|zwitch/.exec(dep)),
+            external: commonConfig.external.filter(dep => !COMPILE_PKG_REGEXP.exec(dep)),
             outfile: "./dist/index.cjs",
             format: "cjs",
         })

--- a/packages/unified-latex-util-glue/build.js
+++ b/packages/unified-latex-util-glue/build.js
@@ -1,5 +1,6 @@
 import esbuild from "esbuild";
 import fs from "node:fs/promises";
+import { isExternal } from "../../scripts/esbuild-module-check.mjs";
 
 (async () => {
     const packageJson = JSON.parse(
@@ -27,7 +28,7 @@ import fs from "node:fs/promises";
     esbuild
         .build({
             ...commonConfig,
-            external: commonConfig.external.filter(dep => !new RegExp(packageJson.internalDependencies).exec(dep)),
+            external: commonConfig.external.filter(isExternal),
             outfile: "./dist/index.cjs",
             format: "cjs",
         })

--- a/packages/unified-latex-util-glue/build.js
+++ b/packages/unified-latex-util-glue/build.js
@@ -27,6 +27,7 @@ import fs from "node:fs/promises";
     esbuild
         .build({
             ...commonConfig,
+            external: commonConfig.external.filter(dep => !/unified|bail|is-plain-obj|trough|vfile.*|unist.*|hast.*|property-information|html-void-elements|.*-separated-tokens|.*entities.*|ccount|rehype*|string-width|strip-ansi|ansi-regex|supports-color|rehype|web-namespaces|zwitch/.exec(dep)),
             outfile: "./dist/index.cjs",
             format: "cjs",
         })

--- a/packages/unified-latex-util-html-like/build.js
+++ b/packages/unified-latex-util-html-like/build.js
@@ -1,6 +1,5 @@
 import esbuild from "esbuild";
 import fs from "node:fs/promises";
-import { COMPILE_PKG_REGEXP } from "../unified-latex/build.js";
 
 (async () => {
     const packageJson = JSON.parse(
@@ -28,7 +27,7 @@ import { COMPILE_PKG_REGEXP } from "../unified-latex/build.js";
     esbuild
         .build({
             ...commonConfig,
-            external: commonConfig.external.filter(dep => !COMPILE_PKG_REGEXP.exec(dep)),
+            external: commonConfig.external.filter(dep => !new RegExp(packageJson.internalDependencies).exec(dep)),
             outfile: "./dist/index.cjs",
             format: "cjs",
         })

--- a/packages/unified-latex-util-html-like/build.js
+++ b/packages/unified-latex-util-html-like/build.js
@@ -1,6 +1,6 @@
 import esbuild from "esbuild";
 import fs from "node:fs/promises";
-import { isExternal } from "../../scripts/esbuild-module-check.mjs";
+import { isCjsPackage } from "../../scripts/esbuild-module-check.mjs";
 
 (async () => {
     const packageJson = JSON.parse(
@@ -28,7 +28,7 @@ import { isExternal } from "../../scripts/esbuild-module-check.mjs";
     esbuild
         .build({
             ...commonConfig,
-            external: commonConfig.external.filter(isExternal),
+            external: commonConfig.external.filter(isCjsPackage),
             outfile: "./dist/index.cjs",
             format: "cjs",
         })

--- a/packages/unified-latex-util-html-like/build.js
+++ b/packages/unified-latex-util-html-like/build.js
@@ -1,5 +1,6 @@
 import esbuild from "esbuild";
 import fs from "node:fs/promises";
+import { COMPILE_PKG_REGEXP } from "../unified-latex/build.js";
 
 (async () => {
     const packageJson = JSON.parse(
@@ -27,7 +28,7 @@ import fs from "node:fs/promises";
     esbuild
         .build({
             ...commonConfig,
-            external: commonConfig.external.filter(dep => !/unified|bail|is-plain-obj|trough|vfile.*|unist.*|hast.*|property-information|html-void-elements|.*-separated-tokens|.*entities.*|ccount|rehype*|string-width|strip-ansi|ansi-regex|supports-color|rehype|web-namespaces|zwitch/.exec(dep)),
+            external: commonConfig.external.filter(dep => !COMPILE_PKG_REGEXP.exec(dep)),
             outfile: "./dist/index.cjs",
             format: "cjs",
         })

--- a/packages/unified-latex-util-html-like/build.js
+++ b/packages/unified-latex-util-html-like/build.js
@@ -1,5 +1,6 @@
 import esbuild from "esbuild";
 import fs from "node:fs/promises";
+import { isExternal } from "../../scripts/esbuild-module-check.mjs";
 
 (async () => {
     const packageJson = JSON.parse(
@@ -27,7 +28,7 @@ import fs from "node:fs/promises";
     esbuild
         .build({
             ...commonConfig,
-            external: commonConfig.external.filter(dep => !new RegExp(packageJson.internalDependencies).exec(dep)),
+            external: commonConfig.external.filter(isExternal),
             outfile: "./dist/index.cjs",
             format: "cjs",
         })

--- a/packages/unified-latex-util-html-like/build.js
+++ b/packages/unified-latex-util-html-like/build.js
@@ -27,6 +27,7 @@ import fs from "node:fs/promises";
     esbuild
         .build({
             ...commonConfig,
+            external: commonConfig.external.filter(dep => !/unified|bail|is-plain-obj|trough|vfile.*|unist.*|hast.*|property-information|html-void-elements|.*-separated-tokens|.*entities.*|ccount|rehype*|string-width|strip-ansi|ansi-regex|supports-color|rehype|web-namespaces|zwitch/.exec(dep)),
             outfile: "./dist/index.cjs",
             format: "cjs",
         })

--- a/packages/unified-latex-util-ligatures/build.js
+++ b/packages/unified-latex-util-ligatures/build.js
@@ -27,6 +27,7 @@ import fs from "node:fs/promises";
     esbuild
         .build({
             ...commonConfig,
+            external: commonConfig.external.filter(dep => !new RegExp(packageJson.internalDependencies).exec(dep)),
             outfile: "./dist/index.cjs",
             format: "cjs",
         })

--- a/packages/unified-latex-util-ligatures/build.js
+++ b/packages/unified-latex-util-ligatures/build.js
@@ -1,6 +1,6 @@
 import esbuild from "esbuild";
 import fs from "node:fs/promises";
-import { isExternal } from "../../scripts/esbuild-module-check.mjs";
+import { isCjsPackage } from "../../scripts/esbuild-module-check.mjs";
 
 (async () => {
     const packageJson = JSON.parse(
@@ -28,7 +28,7 @@ import { isExternal } from "../../scripts/esbuild-module-check.mjs";
     esbuild
         .build({
             ...commonConfig,
-            external: commonConfig.external.filter(isExternal),
+            external: commonConfig.external.filter(isCjsPackage),
             outfile: "./dist/index.cjs",
             format: "cjs",
         })

--- a/packages/unified-latex-util-ligatures/build.js
+++ b/packages/unified-latex-util-ligatures/build.js
@@ -1,5 +1,6 @@
 import esbuild from "esbuild";
 import fs from "node:fs/promises";
+import { isExternal } from "../../scripts/esbuild-module-check.mjs";
 
 (async () => {
     const packageJson = JSON.parse(
@@ -27,7 +28,7 @@ import fs from "node:fs/promises";
     esbuild
         .build({
             ...commonConfig,
-            external: commonConfig.external.filter(dep => !new RegExp(packageJson.internalDependencies).exec(dep)),
+            external: commonConfig.external.filter(isExternal),
             outfile: "./dist/index.cjs",
             format: "cjs",
         })

--- a/packages/unified-latex-util-macros/build.js
+++ b/packages/unified-latex-util-macros/build.js
@@ -1,6 +1,5 @@
 import esbuild from "esbuild";
 import fs from "node:fs/promises";
-import { COMPILE_PKG_REGEXP } from "../unified-latex/build.js";
 
 (async () => {
     const packageJson = JSON.parse(
@@ -28,7 +27,7 @@ import { COMPILE_PKG_REGEXP } from "../unified-latex/build.js";
     esbuild
         .build({
             ...commonConfig,
-            external: commonConfig.external.filter(dep => !COMPILE_PKG_REGEXP.exec(dep)),
+            external: commonConfig.external.filter(dep => !new RegExp(packageJson.internalDependencies).exec(dep)),
             outfile: "./dist/index.cjs",
             format: "cjs",
         })

--- a/packages/unified-latex-util-macros/build.js
+++ b/packages/unified-latex-util-macros/build.js
@@ -1,6 +1,6 @@
 import esbuild from "esbuild";
 import fs from "node:fs/promises";
-import { isExternal } from "../../scripts/esbuild-module-check.mjs";
+import { isCjsPackage } from "../../scripts/esbuild-module-check.mjs";
 
 (async () => {
     const packageJson = JSON.parse(
@@ -28,7 +28,7 @@ import { isExternal } from "../../scripts/esbuild-module-check.mjs";
     esbuild
         .build({
             ...commonConfig,
-            external: commonConfig.external.filter(isExternal),
+            external: commonConfig.external.filter(isCjsPackage),
             outfile: "./dist/index.cjs",
             format: "cjs",
         })

--- a/packages/unified-latex-util-macros/build.js
+++ b/packages/unified-latex-util-macros/build.js
@@ -1,5 +1,6 @@
 import esbuild from "esbuild";
 import fs from "node:fs/promises";
+import { COMPILE_PKG_REGEXP } from "../unified-latex/build.js";
 
 (async () => {
     const packageJson = JSON.parse(
@@ -27,7 +28,7 @@ import fs from "node:fs/promises";
     esbuild
         .build({
             ...commonConfig,
-            external: commonConfig.external.filter(dep => !/unified|bail|is-plain-obj|trough|vfile.*|unist.*|hast.*|property-information|html-void-elements|.*-separated-tokens|.*entities.*|ccount|rehype*|string-width|strip-ansi|ansi-regex|supports-color|rehype|web-namespaces|zwitch/.exec(dep)),
+            external: commonConfig.external.filter(dep => !COMPILE_PKG_REGEXP.exec(dep)),
             outfile: "./dist/index.cjs",
             format: "cjs",
         })

--- a/packages/unified-latex-util-macros/build.js
+++ b/packages/unified-latex-util-macros/build.js
@@ -1,5 +1,6 @@
 import esbuild from "esbuild";
 import fs from "node:fs/promises";
+import { isExternal } from "../../scripts/esbuild-module-check.mjs";
 
 (async () => {
     const packageJson = JSON.parse(
@@ -27,7 +28,7 @@ import fs from "node:fs/promises";
     esbuild
         .build({
             ...commonConfig,
-            external: commonConfig.external.filter(dep => !new RegExp(packageJson.internalDependencies).exec(dep)),
+            external: commonConfig.external.filter(isExternal),
             outfile: "./dist/index.cjs",
             format: "cjs",
         })

--- a/packages/unified-latex-util-macros/build.js
+++ b/packages/unified-latex-util-macros/build.js
@@ -27,6 +27,7 @@ import fs from "node:fs/promises";
     esbuild
         .build({
             ...commonConfig,
+            external: commonConfig.external.filter(dep => !/unified|bail|is-plain-obj|trough|vfile.*|unist.*|hast.*|property-information|html-void-elements|.*-separated-tokens|.*entities.*|ccount|rehype*|string-width|strip-ansi|ansi-regex|supports-color|rehype|web-namespaces|zwitch/.exec(dep)),
             outfile: "./dist/index.cjs",
             format: "cjs",
         })

--- a/packages/unified-latex-util-match/build.js
+++ b/packages/unified-latex-util-match/build.js
@@ -1,6 +1,5 @@
 import esbuild from "esbuild";
 import fs from "node:fs/promises";
-import { COMPILE_PKG_REGEXP } from "../unified-latex/build.js";
 
 (async () => {
     const packageJson = JSON.parse(
@@ -28,7 +27,7 @@ import { COMPILE_PKG_REGEXP } from "../unified-latex/build.js";
     esbuild
         .build({
             ...commonConfig,
-            external: commonConfig.external.filter(dep => !COMPILE_PKG_REGEXP.exec(dep)),
+            external: commonConfig.external.filter(dep => !new RegExp(packageJson.internalDependencies).exec(dep)),
             outfile: "./dist/index.cjs",
             format: "cjs",
         })

--- a/packages/unified-latex-util-match/build.js
+++ b/packages/unified-latex-util-match/build.js
@@ -1,6 +1,6 @@
 import esbuild from "esbuild";
 import fs from "node:fs/promises";
-import { isExternal } from "../../scripts/esbuild-module-check.mjs";
+import { isCjsPackage } from "../../scripts/esbuild-module-check.mjs";
 
 (async () => {
     const packageJson = JSON.parse(
@@ -28,7 +28,7 @@ import { isExternal } from "../../scripts/esbuild-module-check.mjs";
     esbuild
         .build({
             ...commonConfig,
-            external: commonConfig.external.filter(isExternal),
+            external: commonConfig.external.filter(isCjsPackage),
             outfile: "./dist/index.cjs",
             format: "cjs",
         })

--- a/packages/unified-latex-util-match/build.js
+++ b/packages/unified-latex-util-match/build.js
@@ -1,5 +1,6 @@
 import esbuild from "esbuild";
 import fs from "node:fs/promises";
+import { COMPILE_PKG_REGEXP } from "../unified-latex/build.js";
 
 (async () => {
     const packageJson = JSON.parse(
@@ -27,7 +28,7 @@ import fs from "node:fs/promises";
     esbuild
         .build({
             ...commonConfig,
-            external: commonConfig.external.filter(dep => !/unified|bail|is-plain-obj|trough|vfile.*|unist.*|hast.*|property-information|html-void-elements|.*-separated-tokens|.*entities.*|ccount|rehype*|string-width|strip-ansi|ansi-regex|supports-color|rehype|web-namespaces|zwitch/.exec(dep)),
+            external: commonConfig.external.filter(dep => !COMPILE_PKG_REGEXP.exec(dep)),
             outfile: "./dist/index.cjs",
             format: "cjs",
         })

--- a/packages/unified-latex-util-match/build.js
+++ b/packages/unified-latex-util-match/build.js
@@ -1,5 +1,6 @@
 import esbuild from "esbuild";
 import fs from "node:fs/promises";
+import { isExternal } from "../../scripts/esbuild-module-check.mjs";
 
 (async () => {
     const packageJson = JSON.parse(
@@ -27,7 +28,7 @@ import fs from "node:fs/promises";
     esbuild
         .build({
             ...commonConfig,
-            external: commonConfig.external.filter(dep => !new RegExp(packageJson.internalDependencies).exec(dep)),
+            external: commonConfig.external.filter(isExternal),
             outfile: "./dist/index.cjs",
             format: "cjs",
         })

--- a/packages/unified-latex-util-match/build.js
+++ b/packages/unified-latex-util-match/build.js
@@ -27,6 +27,7 @@ import fs from "node:fs/promises";
     esbuild
         .build({
             ...commonConfig,
+            external: commonConfig.external.filter(dep => !/unified|bail|is-plain-obj|trough|vfile.*|unist.*|hast.*|property-information|html-void-elements|.*-separated-tokens|.*entities.*|ccount|rehype*|string-width|strip-ansi|ansi-regex|supports-color|rehype|web-namespaces|zwitch/.exec(dep)),
             outfile: "./dist/index.cjs",
             format: "cjs",
         })

--- a/packages/unified-latex-util-packages/build.js
+++ b/packages/unified-latex-util-packages/build.js
@@ -1,6 +1,5 @@
 import esbuild from "esbuild";
 import fs from "node:fs/promises";
-import { COMPILE_PKG_REGEXP } from "../unified-latex/build.js";
 
 (async () => {
     const packageJson = JSON.parse(
@@ -28,7 +27,7 @@ import { COMPILE_PKG_REGEXP } from "../unified-latex/build.js";
     esbuild
         .build({
             ...commonConfig,
-            external: commonConfig.external.filter(dep => !COMPILE_PKG_REGEXP.exec(dep)),
+            external: commonConfig.external.filter(dep => !new RegExp(packageJson.internalDependencies).exec(dep)),
             outfile: "./dist/index.cjs",
             format: "cjs",
         })

--- a/packages/unified-latex-util-packages/build.js
+++ b/packages/unified-latex-util-packages/build.js
@@ -1,6 +1,6 @@
 import esbuild from "esbuild";
 import fs from "node:fs/promises";
-import { isExternal } from "../../scripts/esbuild-module-check.mjs";
+import { isCjsPackage } from "../../scripts/esbuild-module-check.mjs";
 
 (async () => {
     const packageJson = JSON.parse(
@@ -28,7 +28,7 @@ import { isExternal } from "../../scripts/esbuild-module-check.mjs";
     esbuild
         .build({
             ...commonConfig,
-            external: commonConfig.external.filter(isExternal),
+            external: commonConfig.external.filter(isCjsPackage),
             outfile: "./dist/index.cjs",
             format: "cjs",
         })

--- a/packages/unified-latex-util-packages/build.js
+++ b/packages/unified-latex-util-packages/build.js
@@ -1,5 +1,6 @@
 import esbuild from "esbuild";
 import fs from "node:fs/promises";
+import { COMPILE_PKG_REGEXP } from "../unified-latex/build.js";
 
 (async () => {
     const packageJson = JSON.parse(
@@ -27,7 +28,7 @@ import fs from "node:fs/promises";
     esbuild
         .build({
             ...commonConfig,
-            external: commonConfig.external.filter(dep => !/unified|bail|is-plain-obj|trough|vfile.*|unist.*|hast.*|property-information|html-void-elements|.*-separated-tokens|.*entities.*|ccount|rehype*|string-width|strip-ansi|ansi-regex|supports-color|rehype|web-namespaces|zwitch/.exec(dep)),
+            external: commonConfig.external.filter(dep => !COMPILE_PKG_REGEXP.exec(dep)),
             outfile: "./dist/index.cjs",
             format: "cjs",
         })

--- a/packages/unified-latex-util-packages/build.js
+++ b/packages/unified-latex-util-packages/build.js
@@ -1,5 +1,6 @@
 import esbuild from "esbuild";
 import fs from "node:fs/promises";
+import { isExternal } from "../../scripts/esbuild-module-check.mjs";
 
 (async () => {
     const packageJson = JSON.parse(
@@ -27,7 +28,7 @@ import fs from "node:fs/promises";
     esbuild
         .build({
             ...commonConfig,
-            external: commonConfig.external.filter(dep => !new RegExp(packageJson.internalDependencies).exec(dep)),
+            external: commonConfig.external.filter(isExternal),
             outfile: "./dist/index.cjs",
             format: "cjs",
         })

--- a/packages/unified-latex-util-packages/build.js
+++ b/packages/unified-latex-util-packages/build.js
@@ -27,6 +27,7 @@ import fs from "node:fs/promises";
     esbuild
         .build({
             ...commonConfig,
+            external: commonConfig.external.filter(dep => !/unified|bail|is-plain-obj|trough|vfile.*|unist.*|hast.*|property-information|html-void-elements|.*-separated-tokens|.*entities.*|ccount|rehype*|string-width|strip-ansi|ansi-regex|supports-color|rehype|web-namespaces|zwitch/.exec(dep)),
             outfile: "./dist/index.cjs",
             format: "cjs",
         })

--- a/packages/unified-latex-util-parse/build.js
+++ b/packages/unified-latex-util-parse/build.js
@@ -1,6 +1,5 @@
 import esbuild from "esbuild";
 import fs from "node:fs/promises";
-import { COMPILE_PKG_REGEXP } from "../unified-latex/build.js";
 
 (async () => {
     const packageJson = JSON.parse(
@@ -28,7 +27,7 @@ import { COMPILE_PKG_REGEXP } from "../unified-latex/build.js";
     esbuild
         .build({
             ...commonConfig,
-            external: commonConfig.external.filter(dep => !COMPILE_PKG_REGEXP.exec(dep)),
+            external: commonConfig.external.filter(dep => !new RegExp(packageJson.internalDependencies).exec(dep)),
             outfile: "./dist/index.cjs",
             format: "cjs",
         })

--- a/packages/unified-latex-util-parse/build.js
+++ b/packages/unified-latex-util-parse/build.js
@@ -1,6 +1,6 @@
 import esbuild from "esbuild";
 import fs from "node:fs/promises";
-import { isExternal } from "../../scripts/esbuild-module-check.mjs";
+import { isCjsPackage } from "../../scripts/esbuild-module-check.mjs";
 
 (async () => {
     const packageJson = JSON.parse(
@@ -28,7 +28,7 @@ import { isExternal } from "../../scripts/esbuild-module-check.mjs";
     esbuild
         .build({
             ...commonConfig,
-            external: commonConfig.external.filter(isExternal),
+            external: commonConfig.external.filter(isCjsPackage),
             outfile: "./dist/index.cjs",
             format: "cjs",
         })

--- a/packages/unified-latex-util-parse/build.js
+++ b/packages/unified-latex-util-parse/build.js
@@ -1,5 +1,6 @@
 import esbuild from "esbuild";
 import fs from "node:fs/promises";
+import { COMPILE_PKG_REGEXP } from "../unified-latex/build.js";
 
 (async () => {
     const packageJson = JSON.parse(
@@ -27,7 +28,7 @@ import fs from "node:fs/promises";
     esbuild
         .build({
             ...commonConfig,
-            external: commonConfig.external.filter(dep => !/unified|bail|is-plain-obj|trough|vfile.*|unist.*|hast.*|property-information|html-void-elements|.*-separated-tokens|.*entities.*|ccount|rehype*|string-width|strip-ansi|ansi-regex|supports-color|rehype|web-namespaces|zwitch/.exec(dep)),
+            external: commonConfig.external.filter(dep => !COMPILE_PKG_REGEXP.exec(dep)),
             outfile: "./dist/index.cjs",
             format: "cjs",
         })

--- a/packages/unified-latex-util-parse/build.js
+++ b/packages/unified-latex-util-parse/build.js
@@ -1,5 +1,6 @@
 import esbuild from "esbuild";
 import fs from "node:fs/promises";
+import { isExternal } from "../../scripts/esbuild-module-check.mjs";
 
 (async () => {
     const packageJson = JSON.parse(
@@ -27,7 +28,7 @@ import fs from "node:fs/promises";
     esbuild
         .build({
             ...commonConfig,
-            external: commonConfig.external.filter(dep => !new RegExp(packageJson.internalDependencies).exec(dep)),
+            external: commonConfig.external.filter(isExternal),
             outfile: "./dist/index.cjs",
             format: "cjs",
         })

--- a/packages/unified-latex-util-parse/build.js
+++ b/packages/unified-latex-util-parse/build.js
@@ -27,6 +27,7 @@ import fs from "node:fs/promises";
     esbuild
         .build({
             ...commonConfig,
+            external: commonConfig.external.filter(dep => !/unified|bail|is-plain-obj|trough|vfile.*|unist.*|hast.*|property-information|html-void-elements|.*-separated-tokens|.*entities.*|ccount|rehype*|string-width|strip-ansi|ansi-regex|supports-color|rehype|web-namespaces|zwitch/.exec(dep)),
             outfile: "./dist/index.cjs",
             format: "cjs",
         })

--- a/packages/unified-latex-util-pegjs/build.js
+++ b/packages/unified-latex-util-pegjs/build.js
@@ -1,7 +1,7 @@
 import esbuild from "esbuild";
 import fs from "node:fs/promises";
 import { pegjsLoader } from "../../scripts/esbuild-pegjs-loader.mjs";
-import { isExternal } from "../../scripts/esbuild-module-check.mjs";
+import { isCjsPackage } from "../../scripts/esbuild-module-check.mjs";
 
 (async () => {
     const packageJson = JSON.parse(
@@ -30,7 +30,7 @@ import { isExternal } from "../../scripts/esbuild-module-check.mjs";
     esbuild
         .build({
             ...commonConfig,
-            external: commonConfig.external.filter(isExternal),
+            external: commonConfig.external.filter(isCjsPackage),
             outfile: "./dist/index.cjs",
             format: "cjs",
         })

--- a/packages/unified-latex-util-pegjs/build.js
+++ b/packages/unified-latex-util-pegjs/build.js
@@ -1,6 +1,7 @@
 import esbuild from "esbuild";
 import fs from "node:fs/promises";
 import { pegjsLoader } from "../../scripts/esbuild-pegjs-loader.mjs";
+import { COMPILE_PKG_REGEXP } from "../unified-latex/build.js";
 
 (async () => {
     const packageJson = JSON.parse(
@@ -29,7 +30,7 @@ import { pegjsLoader } from "../../scripts/esbuild-pegjs-loader.mjs";
     esbuild
         .build({
             ...commonConfig,
-            external: commonConfig.external.filter(dep => !/unified|bail|is-plain-obj|trough|vfile.*|unist.*|hast.*|property-information|html-void-elements|.*-separated-tokens|.*entities.*|ccount|rehype*|string-width|strip-ansi|ansi-regex|supports-color|rehype|web-namespaces|zwitch/.exec(dep)),
+            external: commonConfig.external.filter(dep => !COMPILE_PKG_REGEXP.exec(dep)),
             outfile: "./dist/index.cjs",
             format: "cjs",
         })

--- a/packages/unified-latex-util-pegjs/build.js
+++ b/packages/unified-latex-util-pegjs/build.js
@@ -29,6 +29,7 @@ import { pegjsLoader } from "../../scripts/esbuild-pegjs-loader.mjs";
     esbuild
         .build({
             ...commonConfig,
+            external: commonConfig.external.filter(dep => !/unified|bail|is-plain-obj|trough|vfile.*|unist.*|hast.*|property-information|html-void-elements|.*-separated-tokens|.*entities.*|ccount|rehype*|string-width|strip-ansi|ansi-regex|supports-color|rehype|web-namespaces|zwitch/.exec(dep)),
             outfile: "./dist/index.cjs",
             format: "cjs",
         })

--- a/packages/unified-latex-util-pegjs/build.js
+++ b/packages/unified-latex-util-pegjs/build.js
@@ -1,7 +1,6 @@
 import esbuild from "esbuild";
 import fs from "node:fs/promises";
 import { pegjsLoader } from "../../scripts/esbuild-pegjs-loader.mjs";
-import { COMPILE_PKG_REGEXP } from "../unified-latex/build.js";
 
 (async () => {
     const packageJson = JSON.parse(
@@ -30,7 +29,7 @@ import { COMPILE_PKG_REGEXP } from "../unified-latex/build.js";
     esbuild
         .build({
             ...commonConfig,
-            external: commonConfig.external.filter(dep => !COMPILE_PKG_REGEXP.exec(dep)),
+            external: commonConfig.external.filter(dep => !new RegExp(packageJson.internalDependencies).exec(dep)),
             outfile: "./dist/index.cjs",
             format: "cjs",
         })

--- a/packages/unified-latex-util-pegjs/build.js
+++ b/packages/unified-latex-util-pegjs/build.js
@@ -1,6 +1,7 @@
 import esbuild from "esbuild";
 import fs from "node:fs/promises";
 import { pegjsLoader } from "../../scripts/esbuild-pegjs-loader.mjs";
+import { isExternal } from "../../scripts/esbuild-module-check.mjs";
 
 (async () => {
     const packageJson = JSON.parse(
@@ -29,7 +30,7 @@ import { pegjsLoader } from "../../scripts/esbuild-pegjs-loader.mjs";
     esbuild
         .build({
             ...commonConfig,
-            external: commonConfig.external.filter(dep => !new RegExp(packageJson.internalDependencies).exec(dep)),
+            external: commonConfig.external.filter(isExternal),
             outfile: "./dist/index.cjs",
             format: "cjs",
         })

--- a/packages/unified-latex-util-pgfkeys/build.js
+++ b/packages/unified-latex-util-pgfkeys/build.js
@@ -1,6 +1,5 @@
 import esbuild from "esbuild";
 import fs from "node:fs/promises";
-import { COMPILE_PKG_REGEXP } from "../unified-latex/build.js";
 
 (async () => {
     const packageJson = JSON.parse(
@@ -28,7 +27,7 @@ import { COMPILE_PKG_REGEXP } from "../unified-latex/build.js";
     esbuild
         .build({
             ...commonConfig,
-            external: commonConfig.external.filter(dep => !COMPILE_PKG_REGEXP.exec(dep)),
+            external: commonConfig.external.filter(dep => !new RegExp(packageJson.internalDependencies).exec(dep)),
             outfile: "./dist/index.cjs",
             format: "cjs",
         })

--- a/packages/unified-latex-util-pgfkeys/build.js
+++ b/packages/unified-latex-util-pgfkeys/build.js
@@ -1,6 +1,6 @@
 import esbuild from "esbuild";
 import fs from "node:fs/promises";
-import { isExternal } from "../../scripts/esbuild-module-check.mjs";
+import { isCjsPackage } from "../../scripts/esbuild-module-check.mjs";
 
 (async () => {
     const packageJson = JSON.parse(
@@ -28,7 +28,7 @@ import { isExternal } from "../../scripts/esbuild-module-check.mjs";
     esbuild
         .build({
             ...commonConfig,
-            external: commonConfig.external.filter(isExternal),
+            external: commonConfig.external.filter(isCjsPackage),
             outfile: "./dist/index.cjs",
             format: "cjs",
         })

--- a/packages/unified-latex-util-pgfkeys/build.js
+++ b/packages/unified-latex-util-pgfkeys/build.js
@@ -1,5 +1,6 @@
 import esbuild from "esbuild";
 import fs from "node:fs/promises";
+import { COMPILE_PKG_REGEXP } from "../unified-latex/build.js";
 
 (async () => {
     const packageJson = JSON.parse(
@@ -27,7 +28,7 @@ import fs from "node:fs/promises";
     esbuild
         .build({
             ...commonConfig,
-            external: commonConfig.external.filter(dep => !/unified|bail|is-plain-obj|trough|vfile.*|unist.*|hast.*|property-information|html-void-elements|.*-separated-tokens|.*entities.*|ccount|rehype*|string-width|strip-ansi|ansi-regex|supports-color|rehype|web-namespaces|zwitch/.exec(dep)),
+            external: commonConfig.external.filter(dep => !COMPILE_PKG_REGEXP.exec(dep)),
             outfile: "./dist/index.cjs",
             format: "cjs",
         })

--- a/packages/unified-latex-util-pgfkeys/build.js
+++ b/packages/unified-latex-util-pgfkeys/build.js
@@ -1,5 +1,6 @@
 import esbuild from "esbuild";
 import fs from "node:fs/promises";
+import { isExternal } from "../../scripts/esbuild-module-check.mjs";
 
 (async () => {
     const packageJson = JSON.parse(
@@ -27,7 +28,7 @@ import fs from "node:fs/promises";
     esbuild
         .build({
             ...commonConfig,
-            external: commonConfig.external.filter(dep => !new RegExp(packageJson.internalDependencies).exec(dep)),
+            external: commonConfig.external.filter(isExternal),
             outfile: "./dist/index.cjs",
             format: "cjs",
         })

--- a/packages/unified-latex-util-pgfkeys/build.js
+++ b/packages/unified-latex-util-pgfkeys/build.js
@@ -27,6 +27,7 @@ import fs from "node:fs/promises";
     esbuild
         .build({
             ...commonConfig,
+            external: commonConfig.external.filter(dep => !/unified|bail|is-plain-obj|trough|vfile.*|unist.*|hast.*|property-information|html-void-elements|.*-separated-tokens|.*entities.*|ccount|rehype*|string-width|strip-ansi|ansi-regex|supports-color|rehype|web-namespaces|zwitch/.exec(dep)),
             outfile: "./dist/index.cjs",
             format: "cjs",
         })

--- a/packages/unified-latex-util-print-raw/build.js
+++ b/packages/unified-latex-util-print-raw/build.js
@@ -1,6 +1,5 @@
 import esbuild from "esbuild";
 import fs from "node:fs/promises";
-import { COMPILE_PKG_REGEXP } from "../unified-latex/build.js";
 
 (async () => {
     const packageJson = JSON.parse(
@@ -28,7 +27,7 @@ import { COMPILE_PKG_REGEXP } from "../unified-latex/build.js";
     esbuild
         .build({
             ...commonConfig,
-            external: commonConfig.external.filter(dep => !COMPILE_PKG_REGEXP.exec(dep)),
+            external: commonConfig.external.filter(dep => !new RegExp(packageJson.internalDependencies).exec(dep)),
             outfile: "./dist/index.cjs",
             format: "cjs",
         })

--- a/packages/unified-latex-util-print-raw/build.js
+++ b/packages/unified-latex-util-print-raw/build.js
@@ -1,6 +1,6 @@
 import esbuild from "esbuild";
 import fs from "node:fs/promises";
-import { isExternal } from "../../scripts/esbuild-module-check.mjs";
+import { isCjsPackage } from "../../scripts/esbuild-module-check.mjs";
 
 (async () => {
     const packageJson = JSON.parse(
@@ -28,7 +28,7 @@ import { isExternal } from "../../scripts/esbuild-module-check.mjs";
     esbuild
         .build({
             ...commonConfig,
-            external: commonConfig.external.filter(isExternal),
+            external: commonConfig.external.filter(isCjsPackage),
             outfile: "./dist/index.cjs",
             format: "cjs",
         })

--- a/packages/unified-latex-util-print-raw/build.js
+++ b/packages/unified-latex-util-print-raw/build.js
@@ -1,5 +1,6 @@
 import esbuild from "esbuild";
 import fs from "node:fs/promises";
+import { COMPILE_PKG_REGEXP } from "../unified-latex/build.js";
 
 (async () => {
     const packageJson = JSON.parse(
@@ -27,7 +28,7 @@ import fs from "node:fs/promises";
     esbuild
         .build({
             ...commonConfig,
-            external: commonConfig.external.filter(dep => !/unified|bail|is-plain-obj|trough|vfile.*|unist.*|hast.*|property-information|html-void-elements|.*-separated-tokens|.*entities.*|ccount|rehype*|string-width|strip-ansi|ansi-regex|supports-color|rehype|web-namespaces|zwitch/.exec(dep)),
+            external: commonConfig.external.filter(dep => !COMPILE_PKG_REGEXP.exec(dep)),
             outfile: "./dist/index.cjs",
             format: "cjs",
         })

--- a/packages/unified-latex-util-print-raw/build.js
+++ b/packages/unified-latex-util-print-raw/build.js
@@ -1,5 +1,6 @@
 import esbuild from "esbuild";
 import fs from "node:fs/promises";
+import { isExternal } from "../../scripts/esbuild-module-check.mjs";
 
 (async () => {
     const packageJson = JSON.parse(
@@ -27,7 +28,7 @@ import fs from "node:fs/promises";
     esbuild
         .build({
             ...commonConfig,
-            external: commonConfig.external.filter(dep => !new RegExp(packageJson.internalDependencies).exec(dep)),
+            external: commonConfig.external.filter(isExternal),
             outfile: "./dist/index.cjs",
             format: "cjs",
         })

--- a/packages/unified-latex-util-print-raw/build.js
+++ b/packages/unified-latex-util-print-raw/build.js
@@ -27,6 +27,7 @@ import fs from "node:fs/promises";
     esbuild
         .build({
             ...commonConfig,
+            external: commonConfig.external.filter(dep => !/unified|bail|is-plain-obj|trough|vfile.*|unist.*|hast.*|property-information|html-void-elements|.*-separated-tokens|.*entities.*|ccount|rehype*|string-width|strip-ansi|ansi-regex|supports-color|rehype|web-namespaces|zwitch/.exec(dep)),
             outfile: "./dist/index.cjs",
             format: "cjs",
         })

--- a/packages/unified-latex-util-render-info/build.js
+++ b/packages/unified-latex-util-render-info/build.js
@@ -1,6 +1,5 @@
 import esbuild from "esbuild";
 import fs from "node:fs/promises";
-import { COMPILE_PKG_REGEXP } from "../unified-latex/build.js";
 
 (async () => {
     const packageJson = JSON.parse(
@@ -28,7 +27,7 @@ import { COMPILE_PKG_REGEXP } from "../unified-latex/build.js";
     esbuild
         .build({
             ...commonConfig,
-            external: commonConfig.external.filter(dep => !COMPILE_PKG_REGEXP.exec(dep)),
+            external: commonConfig.external.filter(dep => !new RegExp(packageJson.internalDependencies).exec(dep)),
             outfile: "./dist/index.cjs",
             format: "cjs",
         })

--- a/packages/unified-latex-util-render-info/build.js
+++ b/packages/unified-latex-util-render-info/build.js
@@ -1,6 +1,6 @@
 import esbuild from "esbuild";
 import fs from "node:fs/promises";
-import { isExternal } from "../../scripts/esbuild-module-check.mjs";
+import { isCjsPackage } from "../../scripts/esbuild-module-check.mjs";
 
 (async () => {
     const packageJson = JSON.parse(
@@ -28,7 +28,7 @@ import { isExternal } from "../../scripts/esbuild-module-check.mjs";
     esbuild
         .build({
             ...commonConfig,
-            external: commonConfig.external.filter(isExternal),
+            external: commonConfig.external.filter(isCjsPackage),
             outfile: "./dist/index.cjs",
             format: "cjs",
         })

--- a/packages/unified-latex-util-render-info/build.js
+++ b/packages/unified-latex-util-render-info/build.js
@@ -1,5 +1,6 @@
 import esbuild from "esbuild";
 import fs from "node:fs/promises";
+import { COMPILE_PKG_REGEXP } from "../unified-latex/build.js";
 
 (async () => {
     const packageJson = JSON.parse(
@@ -27,7 +28,7 @@ import fs from "node:fs/promises";
     esbuild
         .build({
             ...commonConfig,
-            external: commonConfig.external.filter(dep => !/unified|bail|is-plain-obj|trough|vfile.*|unist.*|hast.*|property-information|html-void-elements|.*-separated-tokens|.*entities.*|ccount|rehype*|string-width|strip-ansi|ansi-regex|supports-color|rehype|web-namespaces|zwitch/.exec(dep)),
+            external: commonConfig.external.filter(dep => !COMPILE_PKG_REGEXP.exec(dep)),
             outfile: "./dist/index.cjs",
             format: "cjs",
         })

--- a/packages/unified-latex-util-render-info/build.js
+++ b/packages/unified-latex-util-render-info/build.js
@@ -1,5 +1,6 @@
 import esbuild from "esbuild";
 import fs from "node:fs/promises";
+import { isExternal } from "../../scripts/esbuild-module-check.mjs";
 
 (async () => {
     const packageJson = JSON.parse(
@@ -27,7 +28,7 @@ import fs from "node:fs/promises";
     esbuild
         .build({
             ...commonConfig,
-            external: commonConfig.external.filter(dep => !new RegExp(packageJson.internalDependencies).exec(dep)),
+            external: commonConfig.external.filter(isExternal),
             outfile: "./dist/index.cjs",
             format: "cjs",
         })

--- a/packages/unified-latex-util-render-info/build.js
+++ b/packages/unified-latex-util-render-info/build.js
@@ -27,6 +27,7 @@ import fs from "node:fs/promises";
     esbuild
         .build({
             ...commonConfig,
+            external: commonConfig.external.filter(dep => !/unified|bail|is-plain-obj|trough|vfile.*|unist.*|hast.*|property-information|html-void-elements|.*-separated-tokens|.*entities.*|ccount|rehype*|string-width|strip-ansi|ansi-regex|supports-color|rehype|web-namespaces|zwitch/.exec(dep)),
             outfile: "./dist/index.cjs",
             format: "cjs",
         })

--- a/packages/unified-latex-util-replace/build.js
+++ b/packages/unified-latex-util-replace/build.js
@@ -1,6 +1,5 @@
 import esbuild from "esbuild";
 import fs from "node:fs/promises";
-import { COMPILE_PKG_REGEXP } from "../unified-latex/build.js";
 
 (async () => {
     const packageJson = JSON.parse(
@@ -28,7 +27,7 @@ import { COMPILE_PKG_REGEXP } from "../unified-latex/build.js";
     esbuild
         .build({
             ...commonConfig,
-            external: commonConfig.external.filter(dep => !COMPILE_PKG_REGEXP.exec(dep)),
+            external: commonConfig.external.filter(dep => !new RegExp(packageJson.internalDependencies).exec(dep)),
             outfile: "./dist/index.cjs",
             format: "cjs",
         })

--- a/packages/unified-latex-util-replace/build.js
+++ b/packages/unified-latex-util-replace/build.js
@@ -1,6 +1,6 @@
 import esbuild from "esbuild";
 import fs from "node:fs/promises";
-import { isExternal } from "../../scripts/esbuild-module-check.mjs";
+import { isCjsPackage } from "../../scripts/esbuild-module-check.mjs";
 
 (async () => {
     const packageJson = JSON.parse(
@@ -28,7 +28,7 @@ import { isExternal } from "../../scripts/esbuild-module-check.mjs";
     esbuild
         .build({
             ...commonConfig,
-            external: commonConfig.external.filter(isExternal),
+            external: commonConfig.external.filter(isCjsPackage),
             outfile: "./dist/index.cjs",
             format: "cjs",
         })

--- a/packages/unified-latex-util-replace/build.js
+++ b/packages/unified-latex-util-replace/build.js
@@ -1,5 +1,6 @@
 import esbuild from "esbuild";
 import fs from "node:fs/promises";
+import { COMPILE_PKG_REGEXP } from "../unified-latex/build.js";
 
 (async () => {
     const packageJson = JSON.parse(
@@ -27,7 +28,7 @@ import fs from "node:fs/promises";
     esbuild
         .build({
             ...commonConfig,
-            external: commonConfig.external.filter(dep => !/unified|bail|is-plain-obj|trough|vfile.*|unist.*|hast.*|property-information|html-void-elements|.*-separated-tokens|.*entities.*|ccount|rehype*|string-width|strip-ansi|ansi-regex|supports-color|rehype|web-namespaces|zwitch/.exec(dep)),
+            external: commonConfig.external.filter(dep => !COMPILE_PKG_REGEXP.exec(dep)),
             outfile: "./dist/index.cjs",
             format: "cjs",
         })

--- a/packages/unified-latex-util-replace/build.js
+++ b/packages/unified-latex-util-replace/build.js
@@ -1,5 +1,6 @@
 import esbuild from "esbuild";
 import fs from "node:fs/promises";
+import { isExternal } from "../../scripts/esbuild-module-check.mjs";
 
 (async () => {
     const packageJson = JSON.parse(
@@ -27,7 +28,7 @@ import fs from "node:fs/promises";
     esbuild
         .build({
             ...commonConfig,
-            external: commonConfig.external.filter(dep => !new RegExp(packageJson.internalDependencies).exec(dep)),
+            external: commonConfig.external.filter(isExternal),
             outfile: "./dist/index.cjs",
             format: "cjs",
         })

--- a/packages/unified-latex-util-replace/build.js
+++ b/packages/unified-latex-util-replace/build.js
@@ -27,6 +27,7 @@ import fs from "node:fs/promises";
     esbuild
         .build({
             ...commonConfig,
+            external: commonConfig.external.filter(dep => !/unified|bail|is-plain-obj|trough|vfile.*|unist.*|hast.*|property-information|html-void-elements|.*-separated-tokens|.*entities.*|ccount|rehype*|string-width|strip-ansi|ansi-regex|supports-color|rehype|web-namespaces|zwitch/.exec(dep)),
             outfile: "./dist/index.cjs",
             format: "cjs",
         })

--- a/packages/unified-latex-util-scan/build.js
+++ b/packages/unified-latex-util-scan/build.js
@@ -1,6 +1,5 @@
 import esbuild from "esbuild";
 import fs from "node:fs/promises";
-import { COMPILE_PKG_REGEXP } from "../unified-latex/build.js";
 
 (async () => {
     const packageJson = JSON.parse(
@@ -28,7 +27,7 @@ import { COMPILE_PKG_REGEXP } from "../unified-latex/build.js";
     esbuild
         .build({
             ...commonConfig,
-            external: commonConfig.external.filter(dep => !COMPILE_PKG_REGEXP.exec(dep)),
+            external: commonConfig.external.filter(dep => !new RegExp(packageJson.internalDependencies).exec(dep)),
             outfile: "./dist/index.cjs",
             format: "cjs",
         })

--- a/packages/unified-latex-util-scan/build.js
+++ b/packages/unified-latex-util-scan/build.js
@@ -1,6 +1,6 @@
 import esbuild from "esbuild";
 import fs from "node:fs/promises";
-import { isExternal } from "../../scripts/esbuild-module-check.mjs";
+import { isCjsPackage } from "../../scripts/esbuild-module-check.mjs";
 
 (async () => {
     const packageJson = JSON.parse(
@@ -28,7 +28,7 @@ import { isExternal } from "../../scripts/esbuild-module-check.mjs";
     esbuild
         .build({
             ...commonConfig,
-            external: commonConfig.external.filter(isExternal),
+            external: commonConfig.external.filter(isCjsPackage),
             outfile: "./dist/index.cjs",
             format: "cjs",
         })

--- a/packages/unified-latex-util-scan/build.js
+++ b/packages/unified-latex-util-scan/build.js
@@ -1,5 +1,6 @@
 import esbuild from "esbuild";
 import fs from "node:fs/promises";
+import { COMPILE_PKG_REGEXP } from "../unified-latex/build.js";
 
 (async () => {
     const packageJson = JSON.parse(
@@ -27,7 +28,7 @@ import fs from "node:fs/promises";
     esbuild
         .build({
             ...commonConfig,
-            external: commonConfig.external.filter(dep => !/unified|bail|is-plain-obj|trough|vfile.*|unist.*|hast.*|property-information|html-void-elements|.*-separated-tokens|.*entities.*|ccount|rehype*|string-width|strip-ansi|ansi-regex|supports-color|rehype|web-namespaces|zwitch/.exec(dep)),
+            external: commonConfig.external.filter(dep => !COMPILE_PKG_REGEXP.exec(dep)),
             outfile: "./dist/index.cjs",
             format: "cjs",
         })

--- a/packages/unified-latex-util-scan/build.js
+++ b/packages/unified-latex-util-scan/build.js
@@ -1,5 +1,6 @@
 import esbuild from "esbuild";
 import fs from "node:fs/promises";
+import { isExternal } from "../../scripts/esbuild-module-check.mjs";
 
 (async () => {
     const packageJson = JSON.parse(
@@ -27,7 +28,7 @@ import fs from "node:fs/promises";
     esbuild
         .build({
             ...commonConfig,
-            external: commonConfig.external.filter(dep => !new RegExp(packageJson.internalDependencies).exec(dep)),
+            external: commonConfig.external.filter(isExternal),
             outfile: "./dist/index.cjs",
             format: "cjs",
         })

--- a/packages/unified-latex-util-scan/build.js
+++ b/packages/unified-latex-util-scan/build.js
@@ -27,6 +27,7 @@ import fs from "node:fs/promises";
     esbuild
         .build({
             ...commonConfig,
+            external: commonConfig.external.filter(dep => !/unified|bail|is-plain-obj|trough|vfile.*|unist.*|hast.*|property-information|html-void-elements|.*-separated-tokens|.*entities.*|ccount|rehype*|string-width|strip-ansi|ansi-regex|supports-color|rehype|web-namespaces|zwitch/.exec(dep)),
             outfile: "./dist/index.cjs",
             format: "cjs",
         })

--- a/packages/unified-latex-util-split/build.js
+++ b/packages/unified-latex-util-split/build.js
@@ -1,6 +1,5 @@
 import esbuild from "esbuild";
 import fs from "node:fs/promises";
-import { COMPILE_PKG_REGEXP } from "../unified-latex/build.js";
 
 (async () => {
     const packageJson = JSON.parse(
@@ -28,7 +27,7 @@ import { COMPILE_PKG_REGEXP } from "../unified-latex/build.js";
     esbuild
         .build({
             ...commonConfig,
-            external: commonConfig.external.filter(dep => !COMPILE_PKG_REGEXP.exec(dep)),
+            external: commonConfig.external.filter(dep => !new RegExp(packageJson.internalDependencies).exec(dep)),
             outfile: "./dist/index.cjs",
             format: "cjs",
         })

--- a/packages/unified-latex-util-split/build.js
+++ b/packages/unified-latex-util-split/build.js
@@ -1,6 +1,6 @@
 import esbuild from "esbuild";
 import fs from "node:fs/promises";
-import { isExternal } from "../../scripts/esbuild-module-check.mjs";
+import { isCjsPackage } from "../../scripts/esbuild-module-check.mjs";
 
 (async () => {
     const packageJson = JSON.parse(
@@ -28,7 +28,7 @@ import { isExternal } from "../../scripts/esbuild-module-check.mjs";
     esbuild
         .build({
             ...commonConfig,
-            external: commonConfig.external.filter(isExternal),
+            external: commonConfig.external.filter(isCjsPackage),
             outfile: "./dist/index.cjs",
             format: "cjs",
         })

--- a/packages/unified-latex-util-split/build.js
+++ b/packages/unified-latex-util-split/build.js
@@ -1,5 +1,6 @@
 import esbuild from "esbuild";
 import fs from "node:fs/promises";
+import { COMPILE_PKG_REGEXP } from "../unified-latex/build.js";
 
 (async () => {
     const packageJson = JSON.parse(
@@ -27,7 +28,7 @@ import fs from "node:fs/promises";
     esbuild
         .build({
             ...commonConfig,
-            external: commonConfig.external.filter(dep => !/unified|bail|is-plain-obj|trough|vfile.*|unist.*|hast.*|property-information|html-void-elements|.*-separated-tokens|.*entities.*|ccount|rehype*|string-width|strip-ansi|ansi-regex|supports-color|rehype|web-namespaces|zwitch/.exec(dep)),
+            external: commonConfig.external.filter(dep => !COMPILE_PKG_REGEXP.exec(dep)),
             outfile: "./dist/index.cjs",
             format: "cjs",
         })

--- a/packages/unified-latex-util-split/build.js
+++ b/packages/unified-latex-util-split/build.js
@@ -1,5 +1,6 @@
 import esbuild from "esbuild";
 import fs from "node:fs/promises";
+import { isExternal } from "../../scripts/esbuild-module-check.mjs";
 
 (async () => {
     const packageJson = JSON.parse(
@@ -27,7 +28,7 @@ import fs from "node:fs/promises";
     esbuild
         .build({
             ...commonConfig,
-            external: commonConfig.external.filter(dep => !new RegExp(packageJson.internalDependencies).exec(dep)),
+            external: commonConfig.external.filter(isExternal),
             outfile: "./dist/index.cjs",
             format: "cjs",
         })

--- a/packages/unified-latex-util-split/build.js
+++ b/packages/unified-latex-util-split/build.js
@@ -27,6 +27,7 @@ import fs from "node:fs/promises";
     esbuild
         .build({
             ...commonConfig,
+            external: commonConfig.external.filter(dep => !/unified|bail|is-plain-obj|trough|vfile.*|unist.*|hast.*|property-information|html-void-elements|.*-separated-tokens|.*entities.*|ccount|rehype*|string-width|strip-ansi|ansi-regex|supports-color|rehype|web-namespaces|zwitch/.exec(dep)),
             outfile: "./dist/index.cjs",
             format: "cjs",
         })

--- a/packages/unified-latex-util-to-string/build.js
+++ b/packages/unified-latex-util-to-string/build.js
@@ -1,6 +1,5 @@
 import esbuild from "esbuild";
 import fs from "node:fs/promises";
-import { COMPILE_PKG_REGEXP } from "../unified-latex/build.js";
 
 (async () => {
     const packageJson = JSON.parse(
@@ -31,7 +30,7 @@ import { COMPILE_PKG_REGEXP } from "../unified-latex/build.js";
     esbuild
         .build({
             ...commonConfig,
-            external: commonConfig.external.filter(dep => !COMPILE_PKG_REGEXP.exec(dep)),
+            external: commonConfig.external.filter(dep => !new RegExp(packageJson.internalDependencies).exec(dep)),
             outfile: "./dist/index.cjs",
             format: "cjs",
         })

--- a/packages/unified-latex-util-to-string/build.js
+++ b/packages/unified-latex-util-to-string/build.js
@@ -30,6 +30,7 @@ import fs from "node:fs/promises";
     esbuild
         .build({
             ...commonConfig,
+            external: commonConfig.external.filter(dep => !/unified|bail|is-plain-obj|trough|vfile.*|unist.*|hast.*|property-information|html-void-elements|.*-separated-tokens|.*entities.*|ccount|rehype*|string-width|strip-ansi|ansi-regex|supports-color|rehype|web-namespaces|zwitch/.exec(dep)),
             outfile: "./dist/index.cjs",
             format: "cjs",
         })

--- a/packages/unified-latex-util-to-string/build.js
+++ b/packages/unified-latex-util-to-string/build.js
@@ -1,5 +1,6 @@
 import esbuild from "esbuild";
 import fs from "node:fs/promises";
+import { COMPILE_PKG_REGEXP } from "../unified-latex/build.js";
 
 (async () => {
     const packageJson = JSON.parse(
@@ -30,7 +31,7 @@ import fs from "node:fs/promises";
     esbuild
         .build({
             ...commonConfig,
-            external: commonConfig.external.filter(dep => !/unified|bail|is-plain-obj|trough|vfile.*|unist.*|hast.*|property-information|html-void-elements|.*-separated-tokens|.*entities.*|ccount|rehype*|string-width|strip-ansi|ansi-regex|supports-color|rehype|web-namespaces|zwitch/.exec(dep)),
+            external: commonConfig.external.filter(dep => !COMPILE_PKG_REGEXP.exec(dep)),
             outfile: "./dist/index.cjs",
             format: "cjs",
         })

--- a/packages/unified-latex-util-to-string/build.js
+++ b/packages/unified-latex-util-to-string/build.js
@@ -1,5 +1,6 @@
 import esbuild from "esbuild";
 import fs from "node:fs/promises";
+import { isExternal } from "../../scripts/esbuild-module-check.mjs";
 
 (async () => {
     const packageJson = JSON.parse(
@@ -30,7 +31,7 @@ import fs from "node:fs/promises";
     esbuild
         .build({
             ...commonConfig,
-            external: commonConfig.external.filter(dep => !new RegExp(packageJson.internalDependencies).exec(dep)),
+            external: commonConfig.external.filter(isExternal),
             outfile: "./dist/index.cjs",
             format: "cjs",
         })

--- a/packages/unified-latex-util-to-string/build.js
+++ b/packages/unified-latex-util-to-string/build.js
@@ -1,6 +1,6 @@
 import esbuild from "esbuild";
 import fs from "node:fs/promises";
-import { isExternal } from "../../scripts/esbuild-module-check.mjs";
+import { isCjsPackage } from "../../scripts/esbuild-module-check.mjs";
 
 (async () => {
     const packageJson = JSON.parse(
@@ -31,7 +31,7 @@ import { isExternal } from "../../scripts/esbuild-module-check.mjs";
     esbuild
         .build({
             ...commonConfig,
-            external: commonConfig.external.filter(isExternal),
+            external: commonConfig.external.filter(isCjsPackage),
             outfile: "./dist/index.cjs",
             format: "cjs",
         })

--- a/packages/unified-latex-util-trim/build.js
+++ b/packages/unified-latex-util-trim/build.js
@@ -1,6 +1,5 @@
 import esbuild from "esbuild";
 import fs from "node:fs/promises";
-import { COMPILE_PKG_REGEXP } from "../unified-latex/build.js";
 
 (async () => {
     const packageJson = JSON.parse(
@@ -28,7 +27,7 @@ import { COMPILE_PKG_REGEXP } from "../unified-latex/build.js";
     esbuild
         .build({
             ...commonConfig,
-            external: commonConfig.external.filter(dep => !COMPILE_PKG_REGEXP.exec(dep)),
+            external: commonConfig.external.filter(dep => !new RegExp(packageJson.internalDependencies).exec(dep)),
             outfile: "./dist/index.cjs",
             format: "cjs",
         })

--- a/packages/unified-latex-util-trim/build.js
+++ b/packages/unified-latex-util-trim/build.js
@@ -1,6 +1,6 @@
 import esbuild from "esbuild";
 import fs from "node:fs/promises";
-import { isExternal } from "../../scripts/esbuild-module-check.mjs";
+import { isCjsPackage } from "../../scripts/esbuild-module-check.mjs";
 
 (async () => {
     const packageJson = JSON.parse(
@@ -28,7 +28,7 @@ import { isExternal } from "../../scripts/esbuild-module-check.mjs";
     esbuild
         .build({
             ...commonConfig,
-            external: commonConfig.external.filter(isExternal),
+            external: commonConfig.external.filter(isCjsPackage),
             outfile: "./dist/index.cjs",
             format: "cjs",
         })

--- a/packages/unified-latex-util-trim/build.js
+++ b/packages/unified-latex-util-trim/build.js
@@ -1,5 +1,6 @@
 import esbuild from "esbuild";
 import fs from "node:fs/promises";
+import { COMPILE_PKG_REGEXP } from "../unified-latex/build.js";
 
 (async () => {
     const packageJson = JSON.parse(
@@ -27,7 +28,7 @@ import fs from "node:fs/promises";
     esbuild
         .build({
             ...commonConfig,
-            external: commonConfig.external.filter(dep => !/unified|bail|is-plain-obj|trough|vfile.*|unist.*|hast.*|property-information|html-void-elements|.*-separated-tokens|.*entities.*|ccount|rehype*|string-width|strip-ansi|ansi-regex|supports-color|rehype|web-namespaces|zwitch/.exec(dep)),
+            external: commonConfig.external.filter(dep => !COMPILE_PKG_REGEXP.exec(dep)),
             outfile: "./dist/index.cjs",
             format: "cjs",
         })

--- a/packages/unified-latex-util-trim/build.js
+++ b/packages/unified-latex-util-trim/build.js
@@ -1,5 +1,6 @@
 import esbuild from "esbuild";
 import fs from "node:fs/promises";
+import { isExternal } from "../../scripts/esbuild-module-check.mjs";
 
 (async () => {
     const packageJson = JSON.parse(
@@ -27,7 +28,7 @@ import fs from "node:fs/promises";
     esbuild
         .build({
             ...commonConfig,
-            external: commonConfig.external.filter(dep => !new RegExp(packageJson.internalDependencies).exec(dep)),
+            external: commonConfig.external.filter(isExternal),
             outfile: "./dist/index.cjs",
             format: "cjs",
         })

--- a/packages/unified-latex-util-trim/build.js
+++ b/packages/unified-latex-util-trim/build.js
@@ -27,6 +27,7 @@ import fs from "node:fs/promises";
     esbuild
         .build({
             ...commonConfig,
+            external: commonConfig.external.filter(dep => !/unified|bail|is-plain-obj|trough|vfile.*|unist.*|hast.*|property-information|html-void-elements|.*-separated-tokens|.*entities.*|ccount|rehype*|string-width|strip-ansi|ansi-regex|supports-color|rehype|web-namespaces|zwitch/.exec(dep)),
             outfile: "./dist/index.cjs",
             format: "cjs",
         })

--- a/packages/unified-latex-util-visit/build.js
+++ b/packages/unified-latex-util-visit/build.js
@@ -1,6 +1,5 @@
 import esbuild from "esbuild";
 import fs from "node:fs/promises";
-import { COMPILE_PKG_REGEXP } from "../unified-latex/build.js";
 
 (async () => {
     const packageJson = JSON.parse(
@@ -28,7 +27,7 @@ import { COMPILE_PKG_REGEXP } from "../unified-latex/build.js";
     esbuild
         .build({
             ...commonConfig,
-            external: commonConfig.external.filter(dep => !COMPILE_PKG_REGEXP.exec(dep)),
+            external: commonConfig.external.filter(dep => !new RegExp(packageJson.internalDependencies).exec(dep)),
             outfile: "./dist/index.cjs",
             format: "cjs",
         })

--- a/packages/unified-latex-util-visit/build.js
+++ b/packages/unified-latex-util-visit/build.js
@@ -1,6 +1,6 @@
 import esbuild from "esbuild";
 import fs from "node:fs/promises";
-import { isExternal } from "../../scripts/esbuild-module-check.mjs";
+import { isCjsPackage } from "../../scripts/esbuild-module-check.mjs";
 
 (async () => {
     const packageJson = JSON.parse(
@@ -28,7 +28,7 @@ import { isExternal } from "../../scripts/esbuild-module-check.mjs";
     esbuild
         .build({
             ...commonConfig,
-            external: commonConfig.external.filter(isExternal),
+            external: commonConfig.external.filter(isCjsPackage),
             outfile: "./dist/index.cjs",
             format: "cjs",
         })

--- a/packages/unified-latex-util-visit/build.js
+++ b/packages/unified-latex-util-visit/build.js
@@ -1,5 +1,6 @@
 import esbuild from "esbuild";
 import fs from "node:fs/promises";
+import { COMPILE_PKG_REGEXP } from "../unified-latex/build.js";
 
 (async () => {
     const packageJson = JSON.parse(
@@ -27,7 +28,7 @@ import fs from "node:fs/promises";
     esbuild
         .build({
             ...commonConfig,
-            external: commonConfig.external.filter(dep => !/unified|bail|is-plain-obj|trough|vfile.*|unist.*|hast.*|property-information|html-void-elements|.*-separated-tokens|.*entities.*|ccount|rehype*|string-width|strip-ansi|ansi-regex|supports-color|rehype|web-namespaces|zwitch/.exec(dep)),
+            external: commonConfig.external.filter(dep => !COMPILE_PKG_REGEXP.exec(dep)),
             outfile: "./dist/index.cjs",
             format: "cjs",
         })

--- a/packages/unified-latex-util-visit/build.js
+++ b/packages/unified-latex-util-visit/build.js
@@ -1,5 +1,6 @@
 import esbuild from "esbuild";
 import fs from "node:fs/promises";
+import { isExternal } from "../../scripts/esbuild-module-check.mjs";
 
 (async () => {
     const packageJson = JSON.parse(
@@ -27,7 +28,7 @@ import fs from "node:fs/promises";
     esbuild
         .build({
             ...commonConfig,
-            external: commonConfig.external.filter(dep => !new RegExp(packageJson.internalDependencies).exec(dep)),
+            external: commonConfig.external.filter(isExternal),
             outfile: "./dist/index.cjs",
             format: "cjs",
         })

--- a/packages/unified-latex-util-visit/build.js
+++ b/packages/unified-latex-util-visit/build.js
@@ -27,6 +27,7 @@ import fs from "node:fs/promises";
     esbuild
         .build({
             ...commonConfig,
+            external: commonConfig.external.filter(dep => !/unified|bail|is-plain-obj|trough|vfile.*|unist.*|hast.*|property-information|html-void-elements|.*-separated-tokens|.*entities.*|ccount|rehype*|string-width|strip-ansi|ansi-regex|supports-color|rehype|web-namespaces|zwitch/.exec(dep)),
             outfile: "./dist/index.cjs",
             format: "cjs",
         })

--- a/packages/unified-latex/build.js
+++ b/packages/unified-latex/build.js
@@ -1,8 +1,6 @@
 import esbuild from "esbuild";
 import fs from "node:fs/promises";
 
-export const COMPILE_PKG_REGEXP = /unified|bail|is-plain-obj|trough|vfile.*|unist.*|hast.*|property-information|html-void-elements|.*-separated-tokens|.*entities.*|ccount|rehype*|string-width|strip-ansi|ansi-regex|supports-color|rehype|web-namespaces|zwitch/;
-
 (async () => {
     const packageJson = JSON.parse(
         await fs.readFile(new URL("./package.json", import.meta.url))
@@ -29,7 +27,7 @@ export const COMPILE_PKG_REGEXP = /unified|bail|is-plain-obj|trough|vfile.*|unis
     esbuild
         .build({
             ...commonConfig,
-            external: commonConfig.external.filter(dep => !COMPILE_PKG_REGEXP.exec(dep)),
+            external: commonConfig.external.filter(dep => !new RegExp(packageJson.internalDependencies).exec(dep)),
             outfile: "./dist/index.cjs",
             format: "cjs",
         })

--- a/packages/unified-latex/build.js
+++ b/packages/unified-latex/build.js
@@ -1,6 +1,8 @@
 import esbuild from "esbuild";
 import fs from "node:fs/promises";
 
+export const COMPILE_PKG_REGEXP = /unified|bail|is-plain-obj|trough|vfile.*|unist.*|hast.*|property-information|html-void-elements|.*-separated-tokens|.*entities.*|ccount|rehype*|string-width|strip-ansi|ansi-regex|supports-color|rehype|web-namespaces|zwitch/;
+
 (async () => {
     const packageJson = JSON.parse(
         await fs.readFile(new URL("./package.json", import.meta.url))
@@ -27,7 +29,7 @@ import fs from "node:fs/promises";
     esbuild
         .build({
             ...commonConfig,
-            external: commonConfig.external.filter(dep => !/unified|bail|is-plain-obj|trough|vfile.*|unist.*|hast.*|property-information|html-void-elements|.*-separated-tokens|.*entities.*|ccount|rehype*|string-width|strip-ansi|ansi-regex|supports-color|rehype|web-namespaces|zwitch/.exec(dep)),
+            external: commonConfig.external.filter(dep => !COMPILE_PKG_REGEXP.exec(dep)),
             outfile: "./dist/index.cjs",
             format: "cjs",
         })

--- a/packages/unified-latex/build.js
+++ b/packages/unified-latex/build.js
@@ -1,6 +1,6 @@
 import esbuild from "esbuild";
 import fs from "node:fs/promises";
-import { isExternal } from "../../scripts/esbuild-module-check.mjs";
+import { isCjsPackage } from "../../scripts/esbuild-module-check.mjs";
 
 (async () => {
     const packageJson = JSON.parse(
@@ -28,7 +28,7 @@ import { isExternal } from "../../scripts/esbuild-module-check.mjs";
     esbuild
         .build({
             ...commonConfig,
-            external: commonConfig.external.filter(isExternal),
+            external: commonConfig.external.filter(isCjsPackage),
             outfile: "./dist/index.cjs",
             format: "cjs",
         })

--- a/packages/unified-latex/build.js
+++ b/packages/unified-latex/build.js
@@ -1,5 +1,6 @@
 import esbuild from "esbuild";
 import fs from "node:fs/promises";
+import { isExternal } from "../../scripts/esbuild-module-check.mjs";
 
 (async () => {
     const packageJson = JSON.parse(
@@ -27,7 +28,7 @@ import fs from "node:fs/promises";
     esbuild
         .build({
             ...commonConfig,
-            external: commonConfig.external.filter(dep => !new RegExp(packageJson.internalDependencies).exec(dep)),
+            external: commonConfig.external.filter(isExternal),
             outfile: "./dist/index.cjs",
             format: "cjs",
         })

--- a/packages/unified-latex/build.js
+++ b/packages/unified-latex/build.js
@@ -27,6 +27,7 @@ import fs from "node:fs/promises";
     esbuild
         .build({
             ...commonConfig,
+            external: commonConfig.external.filter(dep => !/unified|bail|is-plain-obj|trough|vfile.*|unist.*|hast.*|property-information|html-void-elements|.*-separated-tokens|.*entities.*|ccount|rehype*|string-width|strip-ansi|ansi-regex|supports-color|rehype|web-namespaces|zwitch/.exec(dep)),
             outfile: "./dist/index.cjs",
             format: "cjs",
         })

--- a/scripts/esbuild-module-check.mjs
+++ b/scripts/esbuild-module-check.mjs
@@ -1,6 +1,6 @@
 import fs from "node:fs";
 
-export const isExternal = (dependency) => {
+export const isCjsPackage = (dependency) => {
     const path = `../../node_modules/${dependency}/package.json`;
     if (fs.existsSync(path)) {
         return JSON.parse(fs.readFileSync(path)).type !== "module";

--- a/scripts/esbuild-module-check.mjs
+++ b/scripts/esbuild-module-check.mjs
@@ -1,0 +1,9 @@
+import fs from "node:fs";
+
+export const isExternal = (dependency) => {
+    const path = `../../node_modules/${dependency}/package.json`;
+    if (fs.existsSync(path)) {
+        return JSON.parse(fs.readFileSync(path)).type !== "module";
+    }
+    return true;
+};


### PR DESCRIPTION
This is a follow-up of #33 aiming to address #32, in particular the second route of https://github.com/siefkenj/unified-latex/issues/32#issuecomment-1562230505 . Merging this PR can close #32 .

I figure this fix favorable as otherwise the produced `.cjs` won't work with cjs-only platforms, e.g., electron.

The regex is taken from https://github.com/siefkenj/unified-latex/blob/main/package.json#L14-L16