### PR TITLE
Expose more parse plugins from unified-latex-util-parser package

### DIFF
--- a/packages/structured-clone/package.json
+++ b/packages/structured-clone/package.json
@@ -29,7 +29,9 @@
         "compile:tsc": "tsc",
         "compile:esm_and_cjs": "node build.js",
         "compile": "run-p compile:tsc compile:esm_and_cjs",
-        "test": "vitest"
+        "test": "vitest",
+        "package": "node ../../scripts/make-package.mjs",
+        "publish": "cd dist && npm publish"
     },
     "repository": {
         "type": "git",

--- a/packages/unified-latex-util-parse/index.ts
+++ b/packages/unified-latex-util-parse/index.ts
@@ -1,9 +1,12 @@
 export * from "./libs/compiler-ast";
 export * from "./libs/plugin-from-string";
 export * from "./libs/plugin-from-string-minimal";
+export * from "./libs/process-at-letter-and-expl-macros";
+export * from "./libs/process-macros-and-environments";
 export * from "./libs/parse-minimal";
 export * from "./libs/parse";
 export * from "./libs/parse-math";
+export * from "./libs/reparse-math";
 
 // NOTE: The docstring comment must be the last item in the index.ts file!
 /**

--- a/packages/unified-latex-util-to-string/package.json
+++ b/packages/unified-latex-util-to-string/package.json
@@ -5,7 +5,7 @@
     "main": "dist/index.js",
     "type": "module",
     "dependencies": {
-        "@unified-latex/unified-latex-prettier": "^1.4.1",
+        "@unified-latex/unified-latex-prettier": "^1.6.0",
         "@unified-latex/unified-latex-types": "^1.6.0",
         "@unified-latex/unified-latex-util-print-raw": "^1.6.0",
         "prettier": "^2.8.8",


### PR DESCRIPTION
In my use-case, I first perform a minimal parse, apply some transformation, and then resume the rest of the parsing process. Exposing `unifiedLatexProcessAtLetterAndExplMacros` and `unifiedLatexProcessMacrosAndEnvironmentsWithMathReparse` would be nice for this.