### PR TITLE
Use ESM build of vite

### DIFF
--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -16,9 +16,9 @@ jobs:
                 # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
         steps:
-            - uses: actions/checkout@v3
+            - uses: actions/checkout@v4
             - name: Use Node.js ${{ matrix.node-version }}
-              uses: actions/setup-node@v3
+              uses: actions/setup-node@v4
               with:
                   node-version: ${{ matrix.node-version }}
                   cache: "npm"

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
         "./packages/unified-latex-to-*",
         "./packages/*"
     ],
+    "type": "module",
     "scripts": {
         "docs": "typedoc",
         "build": "npm run build -ws",


### PR DESCRIPTION
`npm test` shows following warning message.

> The CJS build of Vite's Node API is deprecated. See https://vitejs.dev/guide/troubleshooting.html#vite-cjs-node-api-deprecated for more details.

It seems that `package.json` in root does not have `"type": "module"` and `vite.config.ts` is used.
I did following:

- Add `type: module` to package.json in root
- ~~Rename all `vite.config.ts` to `vite.config.mts`~~
- ~~Rename all `vite.config.ts` in some files to `vite.config.mts`~~
- ~~Complete extension of relatively imported files in `vite.config.mts`~~
  - ~~Maybe, this is not required.~~
  - Discussed here: https://github.com/siefkenj/unified-latex/pull/90#discussion_r1510140395
- Update some actions used in CI
  - Some actions are using Node v16

