### PR TITLE
Enable caching feature of wireit in GitHub Actions

### DIFF
--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -12,7 +12,7 @@ jobs:
 
         strategy:
             matrix:
-                node-version: [18.x]
+                node-version: [18.x, 20.x]
                 # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
         steps:

--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -22,6 +22,10 @@ jobs:
               with:
                   node-version: ${{ matrix.node-version }}
                   cache: "npm"
+            
+            # Expose some environment variables for wireit
+            - uses: google/wireit@setup-github-actions-caching/v1
+            
             - run: npm ci
 
             - name: Build


### PR DESCRIPTION
wireit has its own caching feature. This PR enables it by adding the action provided officially.
https://github.com/google/wireit?tab=readme-ov-file#github-actions-caching

And, I added Node v20.x to the target of CI. 