### PR TITLE
Fix signature of `\hyphenation`

### DIFF
--- a/packages/unified-latex-ctan/package/latex2e/provides.ts
+++ b/packages/unified-latex-ctan/package/latex2e/provides.ts
@@ -173,7 +173,7 @@ export const macros: MacroInfoRecord = {
         renderInfo: { breakAround: true, pgfkeysArgs: true },
     },
     discretionary: { signature: "m m m" },
-    hyphenation: { signature: "m m m" },
+    hyphenation: { signature: "m" },
     footnote: { signature: "o m", renderInfo: { inParMode: true } },
     footnotemark: { signature: "o" },
     footnotetext: { signature: "o m", renderInfo: { inParMode: true } },


### PR DESCRIPTION
The `\hyphenation` macro has a signature of `m m m`. This caused parsing errors in our cases. I'm not sure if there are other signatures to the one I'm suggesting here, but all usages I found use one required argument with a list of one or more whitespace-separated words. This is in line with the [unofficial latex2e reference manual](https://texdoc.org/serve/latex2e.pdf/0).