### PR TITLE
Fix \underline support

### DIFF
--- a/packages/unified-latex-ctan/package/latex2e/provides.ts
+++ b/packages/unified-latex-ctan/package/latex2e/provides.ts
@@ -287,6 +287,7 @@ export const macros: MacroInfoRecord = {
     textsf: { signature: "m", renderInfo: { inParMode: true } },
     textsc: { signature: "m", renderInfo: { inParMode: true } },
     texttt: { signature: "m", renderInfo: { inParMode: true } },
+    underline: { signature: "m", renderInfo: { inParMode: true } },
     emph: { signature: "m", renderInfo: { inParMode: true } },
     textnormal: { signature: "m", renderInfo: { inParMode: true } },
     uppercase: { signature: "m", renderInfo: { inParMode: true } },

--- a/packages/unified-latex-to-hast/libs/pre-html-subs/macro-subs.ts
+++ b/packages/unified-latex-to-hast/libs/pre-html-subs/macro-subs.ts
@@ -60,7 +60,7 @@ export const macroReplacements: Record<
     textsl: factory("span", { className: "textsl" }),
     textit: factory("i", { className: "textit" }),
     textbf: factory("b", { className: "textbf" }),
-    underline: factory("span", { className: "underline" }),
+    underline: factory("u", { className: "underline" }),
     mbox: factory("span", { className: "mbox" }),
     phantom: factory("span", { className: "phantom" }),
     part: createHeading("h1"),


### PR DESCRIPTION
Add support for `\underline` macro. As for now this macro is not parsed as default. Also changes `<span>` to `<u>` tag usage.