### PR TITLE
Fix nested subscripts parsing #114

### DIFF
--- a/packages/unified-latex-util-pegjs/grammars/latex.pegjs
+++ b/packages/unified-latex-util-pegjs/grammars/latex.pegjs
@@ -69,7 +69,7 @@ math_token "math token"
     = special_macro
     / macro
     / full_comment
-    / whitespace* x:group whitespace* { return x; }
+    / whitespace* x:math_group whitespace* { return x; }
     / whitespace* x:alignment_tab whitespace* { return x; }
     / macro_parameter
     / whitespace* superscript whitespace* {

--- a/packages/unified-latex/libs/unified-latex.ts
+++ b/packages/unified-latex/libs/unified-latex.ts
@@ -28,6 +28,8 @@ export const processLatexViaUnified = (
  * Use `unified()` to a string to an `Ast.Ast` and then return it. This function
  * will not print/pretty-print the `Ast.Ast` back to a string.
  */
-export const processLatexToAstViaUnified = () => {
-    return unified().use(unifiedLatexFromString).use(unifiedLatexAstComplier);
+export const processLatexToAstViaUnified = (
+    options?: ParserPluginOptions
+) => {
+    return unified().use(unifiedLatexFromString, options).use(unifiedLatexAstComplier);
 };


### PR DESCRIPTION
Hi @siefkenj 
This PR should fix #114  
Main change is to replace "group" with "math_group" in "math_token" section of peg latex grammar.
Also add "options" param to `processLatexToAstViaUnified` function which allows ti use "math" mode