### PR TITLE
Upgrade message.position to message.place; remove stray console.log

### DIFF
--- a/packages/unified-latex-to-pretext/libs/author-info.ts
+++ b/packages/unified-latex-to-pretext/libs/author-info.ts
@@ -33,7 +33,7 @@ export function gatherAuthorInfo(ast: Ast.Ast, file: VFile): AuthorInfo[] {
             const message = createVFileMessage(node);
             file.message(
                 message,
-                message.position,
+                message.place,
                 "latex-to-pretext:warning"
             )
         }
@@ -71,7 +71,7 @@ function createVFileMessage(node: Ast.Macro): VFileMessage {
     if (node.position) {
         message.line = node.position.start.line;
         message.column = node.position.start.column;
-        message.position = {
+        message.place = {
             start: {
                 line: node.position.start.line,
                 column: node.position.start.column,

--- a/packages/unified-latex-to-pretext/libs/pre-conversion-subs/macro-subs.ts
+++ b/packages/unified-latex-to-pretext/libs/pre-conversion-subs/macro-subs.ts
@@ -32,7 +32,7 @@ function factory(
                 `Warning: There is no equivalent tag for \"${macro.content}\", \"${tag}\" was used as a replacement.`,
                 "macro-subs"
             );
-            file.message(message, message.position, message.source);
+            file.message(message, message.place, message.source);
         }
 
         // Assume the meaningful argument is the last argument. This

--- a/packages/unified-latex-to-pretext/libs/pre-conversion-subs/utils.ts
+++ b/packages/unified-latex-to-pretext/libs/pre-conversion-subs/utils.ts
@@ -36,7 +36,7 @@ export function emptyStringWithWarningFactory(
             );
             file.message(
                 message,
-                message.position,
+                message.place,
                 `unified-latex-to-pretext:macro-subs`
             );
         }

--- a/packages/unified-latex-to-pretext/libs/unified-latex-plugin-to-pretext-like.ts
+++ b/packages/unified-latex-to-pretext/libs/unified-latex-plugin-to-pretext-like.ts
@@ -112,7 +112,7 @@ export const unifiedLatexToPretextLike: Plugin<
         for (const warningMessage of warningMessages.messages) {
             file.message(
                 warningMessage,
-                warningMessage.position,
+                warningMessage.place,
                 "unified-latex-to-pretext:break-on-boundaries"
             );
         }
@@ -163,7 +163,7 @@ export const unifiedLatexToPretextLike: Plugin<
         for (const warningMessage of unsupportedByKatex.messages) {
             file.message(
                 warningMessage,
-                warningMessage.position,
+                warningMessage.place,
                 "unified-latex-to-pretext:report-unsupported-macro-katex"
             );
         }
@@ -194,7 +194,6 @@ export const unifiedLatexToPretextLike: Plugin<
 
         // Make sure we are actually mutating the current tree.
         originalTree.content = tree.content;
-        console.log(file.messages);
     };
 };
 


### PR DESCRIPTION
This gets rid of the ts warnings about message.position.  It also removes that extra console.log that spit out messages.