### PR TITLE
Environments

### DIFF
--- a/packages/unified-latex-to-pretext/libs/author-info.ts
+++ b/packages/unified-latex-to-pretext/libs/author-info.ts
@@ -31,11 +31,7 @@ export function gatherAuthorInfo(ast: Ast.Ast, file: VFile): AuthorInfo[] {
             authorList.push(authorEmail);
         } else if (match.macro(node, "affil")) {
             const message = createVFileMessage(node);
-            file.message(
-                message,
-                message.place,
-                "latex-to-pretext:warning"
-            )
+            file.message(message, message.place, "latex-to-pretext:warning");
         }
     });
     return authorList;

--- a/packages/unified-latex-to-pretext/libs/pre-conversion-subs/environment-subs.ts
+++ b/packages/unified-latex-to-pretext/libs/pre-conversion-subs/environment-subs.ts
@@ -91,6 +91,29 @@ function enumerateFactory(parentTag = "ol") {
     };
 }
 
+function envFactory(
+    tag: string,
+    statement: boolean = false,
+    warningMessage: string = "",
+    attributes?: Record<string, string>
+) {
+    return (env: Ast.Environment) => {
+        let content;
+        if (statement) {
+            content = htmlLike({
+                tag: "statement",
+                content: wrapPars(env.content)
+            });
+        } else {
+            content = wrapPars(env.content);
+        }
+        return htmlLike({
+            tag: tag,
+            content: content,
+        });
+    };
+}
+
 /**
  * Remove the env environment by returning the content in env only.
  */
@@ -119,9 +142,11 @@ export const environmentReplacements: Record<
         file?: VFile
     ) => Ast.Macro | Ast.String | Ast.Environment | Ast.Node[]
 > = {
+    // TODO: add additional envs like theorem, etc.
     enumerate: enumerateFactory("ol"),
     itemize: enumerateFactory("ul"),
     center: removeEnv,
+    theorem: envFactory("theorem", true),
     tabular: createTableFromTabular,
     quote: (env) => {
         return htmlLike({

--- a/packages/unified-latex-to-pretext/libs/pre-conversion-subs/environment-subs.ts
+++ b/packages/unified-latex-to-pretext/libs/pre-conversion-subs/environment-subs.ts
@@ -1,6 +1,9 @@
 import { htmlLike } from "@unified-latex/unified-latex-util-html-like";
 import * as Ast from "@unified-latex/unified-latex-types";
-import { getArgsContent, getNamedArgsContent } from "@unified-latex/unified-latex-util-arguments";
+import {
+    getArgsContent,
+    getNamedArgsContent,
+} from "@unified-latex/unified-latex-util-arguments";
 import { match } from "@unified-latex/unified-latex-util-match";
 import { wrapPars } from "../wrap-pars";
 import { VisitInfo } from "@unified-latex/unified-latex-util-visit";
@@ -113,19 +116,23 @@ function envFactory(
 
         // Add a statement around the contents of the environment if requested.
         if (requiresStatementTag) {
-            content = [htmlLike({
-                tag: "statement",
-                content: content,
-            })];
+            content = [
+                htmlLike({
+                    tag: "statement",
+                    content: content,
+                }),
+            ];
         }
 
         // Add a title tag if the environment has a title
         const args = getArgsContent(env);
         if (args[0]) {
-            content.unshift(htmlLike({
+            content.unshift(
+                htmlLike({
                     tag: "title",
-                    content: args[0] || []
-                }));
+                    content: args[0] || [],
+                })
+            );
         }
 
         // Put it all together
@@ -181,11 +188,7 @@ export const environmentReplacements: Record<
 function genEnvironmentReplacements() {
     let reps: Record<
         string,
-        (
-            node: Ast.Environment,
-            info: VisitInfo,
-            file?: VFile
-        ) => Ast.Node
+        (node: Ast.Environment, info: VisitInfo, file?: VFile) => Ast.Node
     > = {};
     // First, a long list of pretext environments and their aliases.
     const envAliases: Record<
@@ -198,7 +201,10 @@ function genEnvironmentReplacements() {
         assumption: { requiresStatment: true, aliases: ["assu", "ass"] },
         axiom: { requiresStatment: true, aliases: ["axm"] },
         claim: { requiresStatment: true, aliases: ["cla"] },
-        conjecture: { requiresStatment: true, aliases: ["con", "conj", "conjec"] },
+        conjecture: {
+            requiresStatment: true,
+            aliases: ["con", "conj", "conjec"],
+        },
         construction: { requiresStatment: false, aliases: [] },
         convention: { requiresStatment: false, aliases: ["conv"] },
         corollary: {
@@ -221,7 +227,10 @@ function genEnvironmentReplacements() {
         identity: { requiresStatment: true, aliases: ["idnty"] },
         insight: { requiresStatment: false, aliases: [] },
         investigation: { requiresStatment: false, aliases: [] },
-        lemma: { requiresStatment: true, aliases: ["lem", "lma", "lemm", "lm"] },
+        lemma: {
+            requiresStatment: true,
+            aliases: ["lem", "lma", "lemm", "lm"],
+        },
         notation: {
             requiresStatment: false,
             aliases: ["no", "nota", "ntn", "nt", "notn", "notat"],
@@ -236,7 +245,10 @@ function genEnvironmentReplacements() {
             requiresStatment: true,
             aliases: ["prop", "pro", "prp", "props"],
         },
-        question: { requiresStatment: true, aliases: ["qu", "ques", "quest", "qsn"] },
+        question: {
+            requiresStatment: true,
+            aliases: ["qu", "ques", "quest", "qsn"],
+        },
         remark: {
             requiresStatment: false,
             aliases: ["rem", "rmk", "rema", "bem", "subrem"],
@@ -249,10 +261,14 @@ function genEnvironmentReplacements() {
         warning: { requiresStatment: false, aliases: ["warn", "wrn"] },
     };
     // For each environment PreTeXt has, we create entries for `environmentReplacements` using all reasonable aliases
-    const exapandedEnvAliases = Object.entries(envAliases).flatMap(([env, spec]) => [
-        [env, envFactory(env, spec.requiresStatment)],
-        ...spec.aliases.map(name => [name, envFactory(env, spec.requiresStatment)]),
-    ]);
+    const exapandedEnvAliases = Object.entries(envAliases).flatMap(
+        ([env, spec]) => [
+            [env, envFactory(env, spec.requiresStatment)],
+            ...spec.aliases.map((name) => [
+                name,
+                envFactory(env, spec.requiresStatment),
+            ]),
+        ]
+    );
     return Object.fromEntries(exapandedEnvAliases);
-
 }

--- a/packages/unified-latex-to-pretext/tests/author-info.test.ts
+++ b/packages/unified-latex-to-pretext/tests/author-info.test.ts
@@ -91,7 +91,9 @@ describe("unified-latex-to-pretext:author-info", () => {
             .use(xmlCompilePlugin)
             .runSync({ type: "root", children: [toXast(rendered)].flat() });
         expect(normalizeHtml(toXml(xxx1))).toEqual(
-            normalizeHtml("<author><institution>Affiliation</institution></author>")
+            normalizeHtml(
+                "<author><institution>Affiliation</institution></author>"
+            )
         );
 
         sample =

--- a/packages/unified-latex-to-pretext/tests/unified-latex-to-pretext.test.ts
+++ b/packages/unified-latex-to-pretext/tests/unified-latex-to-pretext.test.ts
@@ -384,9 +384,7 @@ describe("unified-latex-to-pretext:unified-latex-to-pretext", () => {
     it("Gives an environment without statement a title", () => {
         html = process(`\\begin{remark}[My remark]\na\n\\end{remark}`);
         expect(normalizeHtml(html)).toEqual(
-            normalizeHtml(
-                `<remark><title>My remark</title><p>a</p></remark>`
-            )
+            normalizeHtml(`<remark><title>My remark</title><p>a</p></remark>`)
         );
     });
 });

--- a/packages/unified-latex-to-pretext/tests/unified-latex-to-pretext.test.ts
+++ b/packages/unified-latex-to-pretext/tests/unified-latex-to-pretext.test.ts
@@ -358,18 +358,34 @@ describe("unified-latex-to-pretext:unified-latex-to-pretext", () => {
         );
     });
     it("converts theorem-like environments that have statements in ptx", () => {
-        html = process(`\\begin{theorem}\na\n\nb\n\\end{theorem}`);
+        html = process(`\\begin{lemma}\na\n\nb\n\\end{lemma}`);
         expect(normalizeHtml(html)).toEqual(
             normalizeHtml(
-                `<theorem><statement><p>a</p><p>b</p></statement></theorem>`
+                `<lemma><statement><p>a</p><p>b</p></statement></lemma>`
             )
         );
     });
-    it("converts def to definition block", () => {
-        html = process(`\\begin{dfn}\na\n\nb\n\\end{dfn}`);
+    it("converts dfn to definition block", () => {
+        html = process(`\\begin{dfn}\na\n\\end{dfn}`);
         expect(normalizeHtml(html)).toEqual(
             normalizeHtml(
-                `<definition><statement><p>a</p><p>b</p></statement></definition>`
+                `<definition><statement><p>a</p></statement></definition>`
+            )
+        );
+    });
+    it("Gives a theorem a title", () => {
+        html = process(`\\begin{theorem}[My Theorem]\na\n\nb\n\\end{theorem}`);
+        expect(normalizeHtml(html)).toEqual(
+            normalizeHtml(
+                `<theorem><title>My Theorem</title><statement><p>a</p><p>b</p></statement></theorem>`
+            )
+        );
+    });
+    it("Gives an environment without statement a title", () => {
+        html = process(`\\begin{remark}[My remark]\na\n\\end{remark}`);
+        expect(normalizeHtml(html)).toEqual(
+            normalizeHtml(
+                `<remark><title>My remark</title><p>a</p></remark>`
             )
         );
     });

--- a/packages/unified-latex-to-pretext/tests/unified-latex-to-pretext.test.ts
+++ b/packages/unified-latex-to-pretext/tests/unified-latex-to-pretext.test.ts
@@ -357,4 +357,12 @@ describe("unified-latex-to-pretext:unified-latex-to-pretext", () => {
             normalizeHtml(`<yyy>a</yyy><yyy><yyy-child>b</yyy-child>c</yyy>`)
         );
     });
+    it("converts theorem-like environments that have statements in ptx", () => {
+        html = process(`\\begin{theorem}\na\n\nb\n\\end{theorem}`);
+        expect(normalizeHtml(html)).toEqual(
+            normalizeHtml(
+                `<theorem><statement><p>a</p><p>b</p></statement></theorem>`
+            )
+        );
+    })
 });

--- a/packages/unified-latex-to-pretext/tests/unified-latex-to-pretext.test.ts
+++ b/packages/unified-latex-to-pretext/tests/unified-latex-to-pretext.test.ts
@@ -364,5 +364,13 @@ describe("unified-latex-to-pretext:unified-latex-to-pretext", () => {
                 `<theorem><statement><p>a</p><p>b</p></statement></theorem>`
             )
         );
-    })
+    });
+    it("converts def to definition block", () => {
+        html = process(`\\begin{dfn}\na\n\nb\n\\end{dfn}`);
+        expect(normalizeHtml(html)).toEqual(
+            normalizeHtml(
+                `<definition><statement><p>a</p><p>b</p></statement></definition>`
+            )
+        );
+    });
 });


### PR DESCRIPTION
This adds support for `\begin{theorem}...\end{theorem}` conversion, where "theorem" can be replaced by lots of reasonable names that correspond to pretext blocks.  Titles for these environments are also supported.