### PR TITLE
add unified-latex-to-pretext dependency to cjs test package.json

### DIFF
--- a/test/cjs/package.json
+++ b/test/cjs/package.json
@@ -17,6 +17,7 @@
         "@unified-latex/unified-latex-lint": "file:../dist/unified-latex-lint.tgz",
         "@unified-latex/unified-latex-prettier": "file:../dist/unified-latex-prettier.tgz",
         "@unified-latex/unified-latex-to-hast": "file:../dist/unified-latex-to-hast.tgz",
+        "@unified-latex/unified-latex-to-pretext": "file:../dist/unified-latex-to-pretext.tgz",
         "@unified-latex/unified-latex-to-mdast": "file:../dist/unified-latex-to-mdast.tgz",
         "@unified-latex/unified-latex-types": "file:../dist/unified-latex-types.tgz",
         "@unified-latex/unified-latex-util-align": "file:../dist/unified-latex-util-align.tgz",


### PR DESCRIPTION
This adds the unified-latex-to-pretext file as an explicit dependency to the package.json file in the `tests/cjs` folder.  Not sure why it would need to be there and not in the `tests/esm` version, but this seems to resolve the failing tests issue.

PR targets the branch for #127 