### PR TITLE
Support `\ref` and related commands

### DIFF
--- a/packages/unified-latex-to-pretext/libs/convert-to-pretext.ts
+++ b/packages/unified-latex-to-pretext/libs/convert-to-pretext.ts
@@ -6,13 +6,13 @@ import {
     PluginOptions,
 } from "./unified-latex-plugin-to-pretext";
 import { Plugin } from "unified";
-import { Root } from "xast";
+import { Nodes, Root } from "xast";
 
 /**
  * Unified plugin to convert a `XAST` AST to a string.
  */
 export const xmlCompilePlugin: Plugin<void[], Root, string> = function () {
-    this.Compiler = toXml;
+    this.Compiler = (tree: Nodes | Nodes[]) => toXml(tree, { closeEmptyElements: true });
 };
 
 const _processor = processLatexViaUnified()

--- a/packages/unified-latex-to-pretext/libs/pre-conversion-subs/macro-subs.ts
+++ b/packages/unified-latex-to-pretext/libs/pre-conversion-subs/macro-subs.ts
@@ -128,6 +128,47 @@ export const macroReplacements: Record<
             content: args[1] || [],
         });
     },
+    ref: (node) => {
+        const args = getArgsContent(node);
+        const ref = printRaw(args[1] || "");
+        return htmlLike({
+            tag: "xref",
+            attributes: {
+                ref: ref || "",
+                text: "global",
+            },
+        });
+    },
+    cref: (node) => {
+        const args = getArgsContent(node);
+        const ref = printRaw(args[1] || "");
+        return htmlLike({
+            tag: "xref",
+            attributes: {
+                ref: ref || "",
+            },
+        });
+    },
+    Cref: (node) => {
+        const args = getArgsContent(node);
+        const ref = printRaw(args[1] || "");
+        return htmlLike({
+            tag: "xref",
+            attributes: {
+                ref: ref || "",
+            },
+        });
+    },
+    cite: (node) => {
+        const args = getArgsContent(node);
+        const ref = printRaw(args[1] || "");
+        return htmlLike({
+            tag: "xref",
+            attributes: {
+                ref: ref || "",
+            },
+        });
+    },
     "\\": emptyStringWithWarningFactory(
         `Warning: There is no equivalent tag for \"\\\", an empty Ast.String was used as a replacement.`
     ),
@@ -150,6 +191,19 @@ export const macroReplacements: Record<
     noindent: emptyStringWithWarningFactory(
         `Warning: There is no equivalent tag for \"noindent\", an empty Ast.String was used as a replacement.`
     ),
+    latex: (node) => {
+        return htmlLike({tag: "latex"})
+    },
+    latexe: (node) => {
+        return htmlLike({tag: "latex"})
+    },
+    today: (node) => {
+        return htmlLike({tag: "today"})
+    },
+    tex: (node) => {
+        return htmlLike({tag: "tex"})
+    },
+    //tex: factory("tex"),
     includegraphics: (node) => {
         const args = getArgsContent(node);
         const source = printRaw(args[args.length - 1] || []);

--- a/packages/unified-latex-to-pretext/tests/convert-to-pretext.test.ts
+++ b/packages/unified-latex-to-pretext/tests/convert-to-pretext.test.ts
@@ -32,7 +32,7 @@ console.log = (...args) => {
 describe("unified-latex-to-pretext:convert-to-pretext", () => {
     let html: string;
 
-    it("custom replacers work", () => {
+    it("custom replacers work", async () => {
         const process = (value: string) =>
             getParser({
                 macros: { xxx: { signature: "m m" } },
@@ -66,12 +66,12 @@ describe("unified-latex-to-pretext:convert-to-pretext", () => {
         let ast;
 
         ast = process(`\\xxx{a}{b}`);
-        expect(normalizeHtml(convert(ast))).toEqual(
-            normalizeHtml(`<xxx arg0="a" arg1="b"></xxx>`)
+        expect(await normalizeHtml(convert(ast))).toEqual(
+            await normalizeHtml(`<xxx arg0="a" arg1="b"></xxx>`)
         );
     });
 
-    it("full unified pipeline with custom processing", () => {
+    it("full unified pipeline with custom processing", async () => {
         const convert = (value: string) =>
             unified()
                 .use(unifiedLatexFromString)
@@ -96,8 +96,8 @@ describe("unified-latex-to-pretext:convert-to-pretext", () => {
         let ast: string;
 
         ast = convert(`\\includegraphics{myfile.pdf}`);
-        expect(normalizeHtml(ast)).toEqual(
-            normalizeHtml(`<img src="myfile.png"></img>`)
+        expect(await normalizeHtml(ast)).toEqual(
+            await normalizeHtml(`<img src="myfile.png"></img>`)
         );
     });
 });

--- a/packages/unified-latex-to-pretext/tests/unified-latex-to-pretext.test.ts
+++ b/packages/unified-latex-to-pretext/tests/unified-latex-to-pretext.test.ts
@@ -10,7 +10,7 @@ import { xmlCompilePlugin } from "../libs/convert-to-pretext";
 
 function normalizeHtml(str: string) {
     try {
-        return Prettier.format(str, { parser: "html", plugins: ["@prettier/plugin-xml"] });
+        return Prettier.format(str, { parser: "html", plugins: ["@prettier/plugin-xml"] })
     } catch {
         console.warn("Could not format HTML string", str);
         return str;
@@ -44,83 +44,83 @@ describe("unified-latex-to-pretext:unified-latex-to-pretext", () => {
         expect(html).toEqual("<p><alert>a</alert></p><p><alert>b</alert></p>");
     });
 
-    it("Can replace text-style macros", () => {
+    it("Can replace text-style macros", async () => {
         html = process(String.raw`a \textbf{different} word`);
-        expect(normalizeHtml(html)).toEqual(
-            normalizeHtml(`a <alert>different</alert> word`)
+        expect(await normalizeHtml(html)).toEqual(
+            await normalizeHtml(`a <alert>different</alert> word`)
         );
 
         html = process(String.raw`a \textsf{different} word`);
-        expect(normalizeHtml(html)).toEqual(
-            normalizeHtml(`a <em>different</em> word`)
+        expect(await normalizeHtml(html)).toEqual(
+            await normalizeHtml(`a <em>different</em> word`)
         );
 
         html = process(String.raw`a \textrm{different} word`);
-        expect(normalizeHtml(html)).toEqual(
-            normalizeHtml(`a <em>different</em> word`)
+        expect(await normalizeHtml(html)).toEqual(
+            await normalizeHtml(`a <em>different</em> word`)
         );
 
         html = process(String.raw`a \emph{different} word`);
-        expect(normalizeHtml(html)).toEqual(
-            normalizeHtml(`a <em>different</em> word`)
+        expect(await normalizeHtml(html)).toEqual(
+            await normalizeHtml(`a <em>different</em> word`)
         );
     });
 
-    it("Can replace headings", () => {
+    it("Can replace headings", async () => {
         html = process(String.raw`\chapter{My Chapter}`);
-        expect(normalizeHtml(html)).toEqual(
-            normalizeHtml(`<chapter><title>My Chapter</title></chapter>`)
+        expect(await normalizeHtml(html)).toEqual(
+            await normalizeHtml(`<chapter><title>My Chapter</title></chapter>`)
         );
 
         html = process(String.raw`\section{My Section}`);
-        expect(normalizeHtml(html)).toEqual(
-            normalizeHtml(`<section><title>My Section</title></section>`)
+        expect(await normalizeHtml(html)).toEqual(
+            await normalizeHtml(`<section><title>My Section</title></section>`)
         );
 
         html = process(String.raw`\section*{My Section}`);
-        expect(normalizeHtml(html)).toEqual(
-            normalizeHtml(`<section><title>My Section</title></section>`)
+        expect(await normalizeHtml(html)).toEqual(
+            await normalizeHtml(`<section><title>My Section</title></section>`)
         );
     });
 
-    it("Comments are removed from HTML", () => {
+    it("Comments are removed from HTML", async () => {
         html = process(`a % foo\nb`);
-        expect(normalizeHtml(html)).toEqual(normalizeHtml(`a b`));
+        expect(await normalizeHtml(html)).toEqual(await normalizeHtml(`a b`));
 
         html = process(`a% foo\nb`);
-        expect(normalizeHtml(html)).toEqual(normalizeHtml(`ab`));
+        expect(await normalizeHtml(html)).toEqual(await normalizeHtml(`ab`));
 
         html = process(`a% foo\n\nb`);
-        expect(normalizeHtml(html)).toEqual(normalizeHtml(`<p>a</p><p>b</p>`));
+        expect(await normalizeHtml(html)).toEqual(await normalizeHtml(`<p>a</p><p>b</p>`));
 
         html = process(`a % foo\n\nb`);
-        expect(normalizeHtml(html)).toEqual(normalizeHtml(`<p>a</p><p>b</p>`));
+        expect(await normalizeHtml(html)).toEqual(await normalizeHtml(`<p>a</p><p>b</p>`));
     });
 
-    it("Wraps URLs", () => {
+    it("Wraps URLs", async () => {
         html = process(`a\\url{foo.com}b`);
-        expect(normalizeHtml(html)).toEqual(
-            normalizeHtml(`a<url href="foo.com">foo.com</url>b`)
+        expect(await normalizeHtml(html)).toEqual(
+            await normalizeHtml(`a<url href="foo.com">foo.com</url>b`)
         );
 
         html = process(`a\\href{foo.com}{FOO}b`);
-        expect(normalizeHtml(html)).toEqual(
-            normalizeHtml(`a<url href="foo.com">FOO</url>b`)
+        expect(await normalizeHtml(html)).toEqual(
+            await normalizeHtml(`a<url href="foo.com">FOO</url>b`)
         );
     });
 
-    it("Converts enumerate environments", () => {
+    it("Converts enumerate environments", async () => {
         html = process(`\\begin{enumerate}\\item a\\item b\\end{enumerate}`);
-        expect(normalizeHtml(html)).toEqual(
-            normalizeHtml(`<ol><li><p>a</p></li><li><p>b</p></li></ol>`)
+        expect(await normalizeHtml(html)).toEqual(
+            await normalizeHtml(`<ol><li><p>a</p></li><li><p>b</p></li></ol>`)
         );
 
         // Any content before an \item is ignored
         html = process(
             `\\begin{enumerate}before content\\item a\\item b\\end{enumerate}`
         );
-        expect(normalizeHtml(html)).toEqual(
-            normalizeHtml(`<ol><li><p>a</p></li><li><p>b</p></li></ol>`)
+        expect(await normalizeHtml(html)).toEqual(
+            await normalizeHtml(`<ol><li><p>a</p></li><li><p>b</p></li></ol>`)
         );
 
         // Custom labels are handled
@@ -128,8 +128,8 @@ describe("unified-latex-to-pretext:unified-latex-to-pretext", () => {
             `\\begin{enumerate}before content\\item[x)] a\\item[] b\\end{enumerate}`
         );
 
-        expect(normalizeHtml(html)).toEqual(
-            normalizeHtml(
+        expect(await normalizeHtml(html)).toEqual(
+            await normalizeHtml(
                 `<dl>
                     <li><title>x)</title><p>a</p></li>
                     <li><title></title><p>b</p></li>
@@ -138,18 +138,18 @@ describe("unified-latex-to-pretext:unified-latex-to-pretext", () => {
         );
     });
 
-    it("Converts itemize environments", () => {
+    it("Converts itemize environments", async () => {
         html = process(`\\begin{itemize}\\item a\\item b\\end{itemize}`);
-        expect(normalizeHtml(html)).toEqual(
-            normalizeHtml(`<ul><li><p>a</p></li><li><p>b</p></li></ul>`)
+        expect(await normalizeHtml(html)).toEqual(
+            await normalizeHtml(`<ul><li><p>a</p></li><li><p>b</p></li></ul>`)
         );
 
         // Any content before an \item is ignored
         html = process(
             `\\begin{itemize}before content\\item a\\item b\\end{itemize}`
         );
-        expect(normalizeHtml(html)).toEqual(
-            normalizeHtml(`<ul><li><p>a</p></li><li><p>b</p></li></ul>`)
+        expect(await normalizeHtml(html)).toEqual(
+            await normalizeHtml(`<ul><li><p>a</p></li><li><p>b</p></li></ul>`)
         );
 
         // Custom labels are handled
@@ -157,8 +157,8 @@ describe("unified-latex-to-pretext:unified-latex-to-pretext", () => {
             `\\begin{itemize}before content\\item[x)] a\\item[] b\\end{itemize}`
         );
 
-        expect(normalizeHtml(html)).toEqual(
-            normalizeHtml(
+        expect(await normalizeHtml(html)).toEqual(
+            await normalizeHtml(
                 `<dl>
                     <li><title>x)</title><p>a</p></li>
                     <li><title></title><p>b</p></li>
@@ -167,117 +167,117 @@ describe("unified-latex-to-pretext:unified-latex-to-pretext", () => {
         );
     });
 
-    it("Converts tabular environment", () => {
+    it("Converts tabular environment", async () => {
         html = process(`\\begin{tabular}{l l}a & b\\\\c & d\\end{tabular}`);
 
-        expect(normalizeHtml(html)).toEqual(
-            normalizeHtml(
+        expect(await normalizeHtml(html)).toEqual(
+            await normalizeHtml(
                 `<tabular><row><cell>a</cell><cell>b</cell></row><row><cell>c</cell><cell>d</cell></row></tabular>`
             )
         );
     });
 
-    it("Converts tabular environment with different column alignments and borders", () => {
+    it("Converts tabular environment with different column alignments and borders", async () => {
         html = process(`\\begin{tabular}{|r||l|}a & b\\\\c & d\\end{tabular}`);
-        expect(normalizeHtml(html)).toEqual(
-            normalizeHtml(
+        expect(await normalizeHtml(html)).toEqual(
+            await normalizeHtml(
                 `<tabular left="minor"><col halign="right" right="minor"></col><col right="minor"></col>` +
                     `<row><cell>a</cell><cell>b</cell></row><row><cell>c</cell><cell>d</cell></row></tabular>`
             )
         );
     });
 
-    it("Can wrap in <p>...</p> tags", () => {
+    it("Can wrap in <p>...</p> tags", async () => {
         html = process(`a\\par b`);
-        expect(normalizeHtml(html)).toEqual(normalizeHtml(`<p>a</p><p>b</p>`));
+        expect(await normalizeHtml(html)).toEqual(await normalizeHtml(`<p>a</p><p>b</p>`));
 
         html = process(`a\n\n b`);
-        expect(normalizeHtml(html)).toEqual(normalizeHtml(`<p>a</p><p>b</p>`));
+        expect(await normalizeHtml(html)).toEqual(await normalizeHtml(`<p>a</p><p>b</p>`));
 
         html = process(`a\n b\n\nc`);
-        expect(normalizeHtml(html)).toEqual(
-            normalizeHtml(`<p>a b</p><p>c</p>`)
+        expect(await normalizeHtml(html)).toEqual(
+            await normalizeHtml(`<p>a b</p><p>c</p>`)
         );
         html = process(`a\\section{foo} b\n\nc`);
-        expect(normalizeHtml(html)).toEqual(
-            normalizeHtml(
+        expect(await normalizeHtml(html)).toEqual(
+            await normalizeHtml(
                 `<p>a</p><section><title>foo</title><p>b</p><p>c</p></section>`
             )
         );
         html = process(`a\\section{foo} b\\section{bar}\n\nc`);
-        expect(normalizeHtml(html)).toEqual(
-            normalizeHtml(
+        expect(await normalizeHtml(html)).toEqual(
+            await normalizeHtml(
                 `<p>a</p><section><title>foo</title><p>b</p></section><section><title>bar</title><p>c</p></section>`
             )
         );
         html = process(`a\n \\emph{b}\n\nc`);
-        expect(normalizeHtml(html)).toEqual(
-            normalizeHtml(`<p>a <em>b</em></p><p>c</p>`)
+        expect(await normalizeHtml(html)).toEqual(
+            await normalizeHtml(`<p>a <em>b</em></p><p>c</p>`)
         );
         html = process(`a\n b\\begin{foo}x\\end{foo}c\n\nd`);
-        expect(normalizeHtml(html)).toEqual(
-            normalizeHtml(`<p>a b</p>x<p>c</p><p>d</p>`)
+        expect(await normalizeHtml(html)).toEqual(
+            await normalizeHtml(`<p>a b</p>x<p>c</p><p>d</p>`)
         );
     });
 
-    it("Macros aren't replaced with html code in math mode", () => {
+    it("Macros aren't replaced with html code in math mode", async () => {
         let ast;
 
         // Custom labels are handled
         ast = process(`\\[a\\\\b\\]`);
-        expect(normalizeHtml(ast)).toEqual(normalizeHtml(`<me>a\\\\b</me>`));
+        expect(await normalizeHtml(ast)).toEqual(await normalizeHtml(`<me>a\\\\b</me>`));
     });
 
-    it("Ligatures that are nested inside of math mode are not replaced", () => {
+    it("Ligatures that are nested inside of math mode are not replaced", async () => {
         let ast;
 
         // Custom labels are handled
         ast = process(`$a\\text{\\#}b$`);
-        expect(normalizeHtml(ast)).toEqual(
-            normalizeHtml(`<m>a\\text{\\#}b</m>`)
+        expect(await normalizeHtml(ast)).toEqual(
+            await normalizeHtml(`<m>a\\text{\\#}b</m>`)
         );
     });
 
-    it("Pars are broken at display math", () => {
+    it("Pars are broken at display math", async () => {
         let ast;
 
         ast = process(`x\n\ny\\[a\\\\b\\]z`);
-        expect(normalizeHtml(ast)).toEqual(
-            normalizeHtml(`<p>x</p><p>y<me>a\\\\b</me>z</p>`)
+        expect(await normalizeHtml(ast)).toEqual(
+            await normalizeHtml(`<p>x</p><p>y<me>a\\\\b</me>z</p>`)
         );
     });
-    it("replaces command inside argument", () => {
+    it("replaces command inside argument", async () => {
         let ast;
 
         ast = process(`\\emph{\\bfseries b}`);
-        expect(normalizeHtml(ast)).toEqual(
-            normalizeHtml("<em><alert>b</alert></em>")
+        expect(await normalizeHtml(ast)).toEqual(
+            await normalizeHtml("<em><alert>b</alert></em>")
         );
     });
 
-    it("replaces command inside enumerate", () => {
+    it("replaces command inside enumerate", async () => {
         let ast;
 
         ast = process(`\\begin{enumerate}\\item\\bfseries b\\end{enumerate}`);
-        expect(normalizeHtml(ast)).toEqual(
-            normalizeHtml(`<ol>
+        expect(await normalizeHtml(ast)).toEqual(
+            await normalizeHtml(`<ol>
                             <li>
                                 <p><alert>b</alert></p>
                             </li>
                         </ol>`)
         );
     });
-    it("replaces paragraphs", () => {
+    it("replaces paragraphs", async () => {
         let ast;
 
         ast = process(`\\paragraph{Important.} Paragraph`);
-        expect(normalizeHtml(ast)).toEqual(
-            normalizeHtml(
+        expect(await normalizeHtml(ast)).toEqual(
+            await normalizeHtml(
                 `<paragraphs><title>Important.</title> Paragraph</paragraphs>`
             )
         );
     });
-    it("custom replacers work", () => {
+    it("custom replacers work", async () => {
         const process = (value: string) =>
             processLatexViaUnified({ macros: { xxx: { signature: "m m" } } })
                 .use(unifiedLatexToPretext, {
@@ -309,20 +309,20 @@ describe("unified-latex-to-pretext:unified-latex-to-pretext", () => {
         let ast;
 
         ast = process(`\\xxx{a}{b}`);
-        expect(normalizeHtml(ast)).toEqual(
-            normalizeHtml(`<xxx arg0="a" arg1="b"></xxx>`)
+        expect(await normalizeHtml(ast)).toEqual(
+            await normalizeHtml(`<xxx arg0="a" arg1="b"></xxx>`)
         );
 
         ast = process(`\\begin{yyy}a\\end{yyy}`);
-        expect(normalizeHtml(ast)).toEqual(normalizeHtml(`<yyy>a</yyy>`));
+        expect(await normalizeHtml(ast)).toEqual(await normalizeHtml(`<yyy>a</yyy>`));
 
         // Can override default-defined macros
         ast = process(`\\textbf{a}`);
-        expect(normalizeHtml(ast)).toEqual(
-            normalizeHtml(`<my-bold>a</my-bold>`)
+        expect(await normalizeHtml(ast)).toEqual(
+            await normalizeHtml(`<my-bold>a</my-bold>`)
         );
     });
-    it("can use VisitInfo to render nodes differently depending on the parent", () => {
+    it("can use VisitInfo to render nodes differently depending on the parent", async () => {
         const process = (value: string) =>
             processLatexViaUnified()
                 .use(unifiedLatexToPretext, {
@@ -353,38 +353,38 @@ describe("unified-latex-to-pretext:unified-latex-to-pretext", () => {
         ast = process(
             `\\begin{yyy}a\\end{yyy}\\begin{yyy}\\begin{yyy}b\\end{yyy}c\\end{yyy}`
         );
-        expect(normalizeHtml(ast)).toEqual(
-            normalizeHtml(`<yyy>a</yyy><yyy><yyy-child>b</yyy-child>c</yyy>`)
+        expect(await normalizeHtml(ast)).toEqual(
+            await normalizeHtml(`<yyy>a</yyy><yyy><yyy-child>b</yyy-child>c</yyy>`)
         );
     });
-    it("converts theorem-like environments that have statements in ptx", () => {
+    it("converts theorem-like environments that have statements in ptx", async () => {
         html = process(`\\begin{lemma}\na\n\nb\n\\end{lemma}`);
-        expect(normalizeHtml(html)).toEqual(
-            normalizeHtml(
+        expect(await normalizeHtml(html)).toEqual(
+            await normalizeHtml(
                 `<lemma><statement><p>a</p><p>b</p></statement></lemma>`
             )
         );
     });
-    it("converts dfn to definition block", () => {
+    it("converts dfn to definition block", async () => {
         html = process(`\\begin{dfn}\na\n\\end{dfn}`);
-        expect(normalizeHtml(html)).toEqual(
-            normalizeHtml(
+        expect(await normalizeHtml(html)).toEqual(
+           await normalizeHtml(
                 `<definition><statement><p>a</p></statement></definition>`
             )
         );
     });
-    it("Gives a theorem a title", () => {
+    it("Gives a theorem a title", async () => {
         html = process(`\\begin{theorem}[My Theorem]\na\n\nb\n\\end{theorem}`);
-        expect(normalizeHtml(html)).toEqual(
-            normalizeHtml(
+        expect(await normalizeHtml(html)).toEqual(
+           await normalizeHtml(
                 `<theorem><title>My Theorem</title><statement><p>a</p><p>b</p></statement></theorem>`
             )
         );
     });
-    it("Gives an environment without statement a title", () => {
+    it("Gives an environment without statement a title", async () => {
         html = process(`\\begin{remark}[My remark]\na\n\\end{remark}`);
-        expect(normalizeHtml(html)).toEqual(
-            normalizeHtml(`<remark><title>My remark</title><p>a</p></remark>`)
+        return expect(await normalizeHtml(html)).toEqual(
+           await normalizeHtml(`<remark><title>My remark</title><p>a</p></remark>`)
         );
     });
 });

--- a/packages/unified-latex-to-pretext/tests/unified-latex-to-pretext.test.ts
+++ b/packages/unified-latex-to-pretext/tests/unified-latex-to-pretext.test.ts
@@ -132,7 +132,7 @@ describe("unified-latex-to-pretext:unified-latex-to-pretext", () => {
             await normalizeHtml(
                 `<dl>
                     <li><title>x)</title><p>a</p></li>
-                    <li><title></title><p>b</p></li>
+                    <li><title/><p>b</p></li>
                 </dl>`
             )
         );
@@ -161,7 +161,7 @@ describe("unified-latex-to-pretext:unified-latex-to-pretext", () => {
             await normalizeHtml(
                 `<dl>
                     <li><title>x)</title><p>a</p></li>
-                    <li><title></title><p>b</p></li>
+                    <li><title/><p>b</p></li>
                 </dl>`
             )
         );
@@ -181,7 +181,7 @@ describe("unified-latex-to-pretext:unified-latex-to-pretext", () => {
         html = process(`\\begin{tabular}{|r||l|}a & b\\\\c & d\\end{tabular}`);
         expect(await normalizeHtml(html)).toEqual(
             await normalizeHtml(
-                `<tabular left="minor"><col halign="right" right="minor"></col><col right="minor"></col>` +
+                `<tabular left="minor"><col halign="right" right="minor"/><col right="minor"/>` +
                     `<row><cell>a</cell><cell>b</cell></row><row><cell>c</cell><cell>d</cell></row></tabular>`
             )
         );
@@ -310,7 +310,7 @@ describe("unified-latex-to-pretext:unified-latex-to-pretext", () => {
 
         ast = process(`\\xxx{a}{b}`);
         expect(await normalizeHtml(ast)).toEqual(
-            await normalizeHtml(`<xxx arg0="a" arg1="b"></xxx>`)
+            await normalizeHtml(`<xxx arg0="a" arg1="b"/>`)
         );
 
         ast = process(`\\begin{yyy}a\\end{yyy}`);

--- a/packages/unified-latex-to-pretext/tests/unified-latex-to-pretext.test.ts
+++ b/packages/unified-latex-to-pretext/tests/unified-latex-to-pretext.test.ts
@@ -387,4 +387,31 @@ describe("unified-latex-to-pretext:unified-latex-to-pretext", () => {
            await normalizeHtml(`<remark><title>My remark</title><p>a</p></remark>`)
         );
     });
+    it("Replaces \\ref with a xref", async () => {
+        html = process(`Exercise \\ref{foo} is important`);
+        expect(await normalizeHtml(html)).toEqual(
+            await normalizeHtml(`Exercise <xref ref="foo" text="global"/> is important`)
+        );
+    });
+    it("Replaces \\cref and \\Cref with a bare xref", async () => {
+        html = process(`As we saw in \\cref{foo}, we can do this.`);
+        expect(await normalizeHtml(html)).toEqual(
+            await normalizeHtml(`As we saw in <xref ref="foo"/>, we can do this.`)
+        );
+
+        html = process(`As we saw in \\Cref{foo}, we can do this.`);
+        expect(await normalizeHtml(html)).toEqual(
+            await normalizeHtml(`As we saw in <xref ref="foo" />, we can do this.`)
+        );
+    });
+    it("Replaces \\cite with a xref", async () => {
+        html = process(`See \\cite{foo} for more`);
+        expect(await normalizeHtml(html)).toEqual(
+            await normalizeHtml(`See <xref ref="foo" /> for more`)
+        );
+    });
+    it("Replaces \\latex with <latex/> etc.", async () => {
+        html = process(`We can write in \\latex or \\tex and do so \\today.`);
+        expect(await normalizeHtml(html)).toEqual(await normalizeHtml(`We can write in <latex/> or <tex/> and do so <today/>.`));
+    })
 });


### PR DESCRIPTION
This adds replacements for `\ref`, `\cref`, `\Cref`, `\cite`, as well as `\latex`, `\latexe` (just as `<latex/>`, `\tex`, and `\today`.

Built on top of #130 so that test pass.  I can rebase and force push after that is merged if that's easier. 