### PR TITLE
use code hast type for verb

### DIFF
--- a/packages/unified-latex-to-hast/libs/html-subs/to-hast.ts
+++ b/packages/unified-latex-to-hast/libs/html-subs/to-hast.ts
@@ -69,6 +69,7 @@ export function toHastWithLoggerFactory(
                     printRaw(node.content)
                 );
             case "verb":
+                return h('code', { className: node.env }, printRaw(node.content));
             case "verbatim":
                 return h("pre", { className: node.env }, node.content);
             case "whitespace":


### PR DESCRIPTION
Hello 👋

When converted to HAST, the `\verb` macro is currently considered equivalent to the `\verbatim` macro.  

From an HTML/CSS perspective, `\verb` can be considered an inline element and `\verbatim` a block element.

I propose differentiating between the two, using `<code>` for `\verb` and `<pre>` for `\verbatim`.

---

Currently, when converting the following LaTeX to Markdown:

```latex
An \verb|example\n| of \emph{this}!
```

The output is:

````md
An

```
example\n
```

of *this*!
````

When I focused on fixing the Markdown output [here](https://github.com/siefkenj/unified-latex/blob/962aa0db7965e3b19c365a1d74d3d8af7980ec09/packages/unified-latex-to-mdast/libs/remark-handlers-defaults.ts) like so:

```ts
pre(state, node, parent) {
  const className = (node.properties.className || []) as string[];
  if (className.includes('verb')) {
    return { type: 'inlineCode', value: toString(node) };
  }
  return state.all(node);
}
```

The Markdown serializes to:

````md
An`example\n`of *this*!
````

Losing it's surrounding whitespace, presumably because the `<pre>` element being treated as a block-level element somewhere in the chain.

Thanks.