### PR TITLE
add support for eqref

### DIFF
--- a/packages/unified-latex-ctan/package/mathtools/provides.ts
+++ b/packages/unified-latex-ctan/package/mathtools/provides.ts
@@ -110,6 +110,9 @@ export const macros: MacroInfoRecord = {
         signature: "s m m",
         renderInfo: { breakAround: true },
     },
+    eqref: {
+        signature: "m",
+    }
 };
 
 export const environments: EnvInfoRecord = {

--- a/packages/unified-latex-to-pretext/libs/pre-conversion-subs/macro-subs.ts
+++ b/packages/unified-latex-to-pretext/libs/pre-conversion-subs/macro-subs.ts
@@ -139,6 +139,16 @@ export const macroReplacements: Record<
             },
         });
     },
+    eqref: (node) => {
+        const args = getArgsContent(node);
+        const ref = printRaw(args[0] || "");
+        return htmlLike({
+            tag: "xref",
+            attributes: {
+                ref: ref || "",
+            },
+        });
+    },
     cref: (node) => {
         const args = getArgsContent(node);
         const ref = printRaw(args[1] || "");

--- a/packages/unified-latex-to-pretext/tests/unified-latex-to-pretext.test.ts
+++ b/packages/unified-latex-to-pretext/tests/unified-latex-to-pretext.test.ts
@@ -414,6 +414,14 @@ describe("unified-latex-to-pretext:unified-latex-to-pretext", () => {
             )
         );
     });
+    it("Replaces \\eqref with a xref", async () => {
+        html = process(`Exercise \\eqref{foo} is important`);
+        expect(await normalizeHtml(html)).toEqual(
+            await normalizeHtml(
+                `Exercise <xref ref="foo"/> is important`
+            )
+        );
+    });
     it("Replaces \\cref and \\Cref with a bare xref", async () => {
         html = process(`As we saw in \\cref{foo}, we can do this.`);
         expect(await normalizeHtml(html)).toEqual(


### PR DESCRIPTION
This was going to be part of a larger PR with a number of small fixes.  But it turns out that just adding eqref to the macro-subs was insufficient.  I believe this is because the signature for eqref is not part of the packages in `unified-latex-ctan`. So I added a package for amsmath there; currently it just has the eqref macro.  But of course, if this the right approach, I can add more environments and macros there too.

If I should be starting this somewhere else, let me know.