### PR TITLE
add support for custom \term macro

### DIFF
--- a/packages/unified-latex-to-pretext/index.ts
+++ b/packages/unified-latex-to-pretext/index.ts
@@ -3,6 +3,7 @@ export * from "./libs/unified-latex-wrap-pars";
 export * from "./libs/pre-conversion-subs/katex-subs";
 export * from "./libs/wrap-pars";
 export * from "./libs/convert-to-pretext";
+export * from "./libs/provides";
 
 // NOTE: The docstring comment must be the last item in the index.ts file!
 /**

--- a/packages/unified-latex-to-pretext/libs/pre-conversion-subs/macro-subs.ts
+++ b/packages/unified-latex-to-pretext/libs/pre-conversion-subs/macro-subs.ts
@@ -84,6 +84,7 @@ export const macroReplacements: Record<
     ),
     textit: factory("em"),
     textbf: factory("alert"),
+    term: factory("term"),
     underline: factory(
         "em",
         `Warning: There is no equivalent tag for \"underline\", \"em\" was used as a replacement.`

--- a/packages/unified-latex-to-pretext/libs/provides.ts
+++ b/packages/unified-latex-to-pretext/libs/provides.ts
@@ -1,0 +1,16 @@
+import {
+    MacroInfoRecord,
+    EnvInfoRecord,
+} from "@unified-latex/unified-latex-types";
+
+/**
+ * Register macro signatures for PreTeXt-specific macros.
+ * Add new macro names here when they are handled in macro-subs.ts
+ * but not already defined in the unified-latex-ctan packages.
+ */
+export const macros: MacroInfoRecord = {
+    // PreTeXt-specific macro
+    term: { signature: "m" },
+};
+
+export const environments: EnvInfoRecord = {};

--- a/packages/unified-latex-to-pretext/libs/unified-latex-plugin-to-pretext.ts
+++ b/packages/unified-latex-to-pretext/libs/unified-latex-plugin-to-pretext.ts
@@ -6,12 +6,14 @@ import { TypeGuard } from "@unified-latex/unified-latex-types";
 import { expandUnicodeLigatures } from "@unified-latex/unified-latex-util-ligatures";
 import { match } from "@unified-latex/unified-latex-util-match";
 import { EXIT, visit } from "@unified-latex/unified-latex-util-visit";
+import { attachMacroArgs } from "@unified-latex/unified-latex-util-arguments";
 import { toPretextWithLoggerFactory } from "./pretext-subs/to-pretext";
 import {
     unifiedLatexToPretextLike,
     PluginOptions as HtmlLikePluginOptions,
 } from "./unified-latex-plugin-to-pretext-like";
 import { expandUserDefinedMacros } from "./pre-conversion-subs/expand-user-defined-macros";
+import { macros as pretextMacros } from "./provides";
 
 export type PluginOptions = HtmlLikePluginOptions & {
     /**
@@ -36,6 +38,9 @@ export const unifiedLatexToPretext: Plugin<
 
         // expand user defined macros
         expandUserDefinedMacros(tree);
+
+        // Attach PreTeXt-specific macro arguments
+        attachMacroArgs(tree, pretextMacros);
 
         // If there is a \begin{document}...\end{document}, that's the only
         // content we want to convert.

--- a/packages/unified-latex-to-pretext/tests/unified-latex-to-pretext.test.ts
+++ b/packages/unified-latex-to-pretext/tests/unified-latex-to-pretext.test.ts
@@ -443,4 +443,12 @@ describe("unified-latex-to-pretext:unified-latex-to-pretext", () => {
             )
         );
     });
+    it("Replaces \\term with <term> env", async () => {
+        html = process(`We can write a \\term{specific term} when defining something.`);
+        expect(await normalizeHtml(html)).toEqual(
+            await normalizeHtml(
+                `We can write a <term>specific term</term> when defining something.`
+            )
+        );
+    });
 });


### PR DESCRIPTION
Here is another one similar to #148, but here the new macro is pretext specific.  That is, we are thinking about encouraging/requiring authors write using a nascent "pretext.sty" latex package that includes pretext-like semantic macros and environments.  Many of these correspond with what other packages provide, but some don't.  

Is the contents of this PR a reasonable way to approach this?  That is, replicate the sort of logic used in the `unified-latex- ctan` but keep it inside `unified-latex-to-pretext`.